### PR TITLE
fix(lsp): workspace-wide symbol resolution and correctness fixes

### DIFF
--- a/crates/sema-lsp/src/handlers/completion.rs
+++ b/crates/sema-lsp/src/handlers/completion.rs
@@ -84,6 +84,44 @@ impl BackendState {
             }
         }
 
+        // Workspace symbols from still-fresh scanned files, so a sibling
+        // file's definitions complete without opening it. On a name clash,
+        // whatever was emitted above wins (special forms, builtins, the
+        // current document's user definitions). Full-cache iteration per
+        // request is the same pattern references and rename use.
+        let mut emitted: std::collections::HashSet<String> =
+            items.iter().map(|i| i.label.clone()).collect();
+        let mut scanned: Vec<_> = self
+            .import_cache
+            .iter()
+            .filter(|(path, entry)| entry.is_fresh(path))
+            .collect();
+        // Deterministic completion order despite arbitrary map order.
+        scanned.sort_by(|a, b| a.0.cmp(b.0));
+        for (path, entry) in scanned {
+            let uri_string = match Url::from_file_path(path) {
+                Ok(u) => u.to_string(),
+                Err(_) => continue,
+            };
+            // Names only; ranges discarded — &[] skips UTF-16 mapping.
+            let defs =
+                user_definitions_from_ast(&entry.ast, &entry.span_map, &entry.symbol_spans, &[]);
+            for (name, _) in defs {
+                if !(prefix.is_empty() || name.starts_with(prefix)) || emitted.contains(&name) {
+                    continue;
+                }
+                let detail = extract_params_from_ast(&entry.ast, &name);
+                emitted.insert(name.clone());
+                items.push(CompletionItem {
+                    label: name,
+                    kind: Some(CompletionItemKind::FUNCTION),
+                    detail,
+                    data: Some(serde_json::Value::String(uri_string.clone())),
+                    ..Default::default()
+                });
+            }
+        }
+
         // Local bindings from scope tree
         if let Some(cached) = self.cached_parses.get(uri_str) {
             let sema_line = position.line as usize + 1;
@@ -147,6 +185,15 @@ impl BackendState {
                 return Some(doc);
             }
         }
+        // Scanned workspace files (covers items completed from the scan cache).
+        for (path, entry) in &self.import_cache {
+            if !entry.is_fresh(path) {
+                continue;
+            }
+            if let Some(doc) = extract_docstring_from_ast(&entry.ast, name) {
+                return Some(doc);
+            }
+        }
         None
     }
 
@@ -175,6 +222,15 @@ impl BackendState {
         }
         for cached in self.cached_parses.values() {
             if let Some(params) = extract_params_from_ast(&cached.ast, name) {
+                return Some(render(params));
+            }
+        }
+        // Scanned workspace files (covers items completed from the scan cache).
+        for (path, entry) in &self.import_cache {
+            if !entry.is_fresh(path) {
+                continue;
+            }
+            if let Some(params) = extract_params_from_ast(&entry.ast, name) {
                 return Some(render(params));
             }
         }

--- a/crates/sema-lsp/src/handlers/hover.rs
+++ b/crates/sema-lsp/src/handlers/hover.rs
@@ -125,6 +125,23 @@ impl BackendState {
             }
         }
 
-        None
+        // Fall back to a workspace-wide search (other open documents, then
+        // still-fresh scanned files), mirroring goto-definition Phase 3d.
+        // Attributed as "Defined in" so the user can tell a workspace match
+        // from an explicit import ("Imported from").
+        let (ast, module_name) = self.find_workspace_definition(uri, &symbol)?;
+        let mut hover_text = format!("```sema\n({symbol}");
+        if let Some(params) = extract_params_from_ast(ast, &symbol) {
+            hover_text.push(' ');
+            hover_text.push_str(&params);
+        }
+        hover_text.push_str(&format!(")\n```\n\n*Defined in `{module_name}`*"));
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: hover_text,
+            }),
+            range: None,
+        })
     }
 }

--- a/crates/sema-lsp/src/handlers/navigation.rs
+++ b/crates/sema-lsp/src/handlers/navigation.rs
@@ -87,7 +87,7 @@ impl BackendState {
         // treat top-level symbols as workspace-global. Without this, a
         // definition in a sibling file that is not explicitly imported is
         // unreachable even though the scan has already parsed it.
-        let mut searched_uris = std::collections::HashSet::new();
+        let mut searched_paths = std::collections::HashSet::new();
         let mut locations = Vec::new();
 
         for (doc_uri_str, cached) in &self.cached_parses {
@@ -95,7 +95,9 @@ impl BackendState {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            searched_uris.insert(doc_uri_str.clone());
+            if let Ok(doc_path) = doc_uri.to_file_path() {
+                searched_paths.insert(canonicalize_or_raw(&doc_path));
+            }
             let doc_lines: Vec<&str> = cached.source.lines().collect();
             let defs = user_definitions_from_ast(
                 &cached.ast,
@@ -116,15 +118,20 @@ impl BackendState {
         }
 
         // Files known only from the workspace scan (import_cache); skip files
-        // already covered above via their open-document parse.
+        // already covered above via their open-document parse — by canonical
+        // path, since one file may be addressed under several spellings —
+        // and entries whose on-disk file changed or vanished since the scan.
         for (path, import_cached) in &self.import_cache {
+            if searched_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
             let import_uri = match Url::from_file_path(path) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            if searched_uris.contains(import_uri.as_str()) {
-                continue;
-            }
             let import_lines: Vec<&str> = import_cached.source.lines().collect();
             let defs = user_definitions_from_ast(
                 &import_cached.ast,
@@ -203,14 +210,16 @@ impl BackendState {
         // Top-level/global symbol — search all open documents, but skip
         // occurrences that are shadowed by local bindings in each document.
         let mut locations = Vec::new();
-        let mut searched_uris = std::collections::HashSet::new();
+        let mut searched_paths = std::collections::HashSet::new();
 
         for (doc_uri_str, cached) in &self.cached_parses {
             let doc_uri = match Url::parse(doc_uri_str) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            searched_uris.insert(doc_uri_str.clone());
+            if let Ok(doc_path) = doc_uri.to_file_path() {
+                searched_paths.insert(canonicalize_or_raw(&doc_path));
+            }
             let doc_lines: Vec<&str> = self
                 .documents
                 .get(doc_uri_str)
@@ -233,16 +242,21 @@ impl BackendState {
             }
         }
 
-        // Also search workspace files not currently open (import_cache)
+        // Also search workspace files not currently open (import_cache).
+        // Skip files already searched via cached_parses — by canonical path,
+        // since one file may be addressed under several spellings — and
+        // entries whose on-disk file changed or vanished since the scan.
         for (path, import_cached) in &self.import_cache {
+            if searched_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
             let import_uri = match Url::from_file_path(path) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            // Skip files already searched via cached_parses
-            if searched_uris.contains(import_uri.as_str()) {
-                continue;
-            }
             let import_lines: Vec<&str> = import_cached.source.lines().collect();
             for (name, span) in &import_cached.symbol_spans {
                 if name != symbol {
@@ -433,14 +447,16 @@ impl BackendState {
 
         // Top-level/global symbol — rename across all documents,
         // but skip occurrences shadowed by local bindings.
-        let mut searched_uris = std::collections::HashSet::new();
+        let mut searched_paths = std::collections::HashSet::new();
 
         for (doc_uri_str, cached) in &self.cached_parses {
             let doc_uri = match Url::parse(doc_uri_str) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            searched_uris.insert(doc_uri_str.clone());
+            if let Ok(doc_path) = doc_uri.to_file_path() {
+                searched_paths.insert(canonicalize_or_raw(&doc_path));
+            }
             let doc_lines: Vec<&str> = self
                 .documents
                 .get(doc_uri_str)
@@ -465,15 +481,24 @@ impl BackendState {
             }
         }
 
-        // Also rename in workspace files not currently open (import_cache)
+        // Also rename in workspace files not currently open (import_cache).
+        // Skip files already renamed via cached_parses — by canonical path,
+        // since one file may be addressed under several spellings (duplicate
+        // edits for one file would each be applied, corrupting it) — and
+        // entries whose on-disk file changed or vanished since the scan:
+        // their stale offsets would corrupt the file too, so missing that
+        // file is the safe behavior.
         for (path, import_cached) in &self.import_cache {
+            if searched_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
             let import_uri = match Url::from_file_path(path) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            if searched_uris.contains(import_uri.as_str()) {
-                continue;
-            }
             let import_lines: Vec<&str> = import_cached.source.lines().collect();
             let mut edits = Vec::new();
             for (name, span) in &import_cached.symbol_spans {

--- a/crates/sema-lsp/src/handlers/navigation.rs
+++ b/crates/sema-lsp/src/handlers/navigation.rs
@@ -82,7 +82,76 @@ impl BackendState {
             }
         }
 
-        None
+        // Phase 3d: Fall back to a workspace-wide search over open documents
+        // and the workspace scan cache, mirroring how references and rename
+        // treat top-level symbols as workspace-global. Without this, a
+        // definition in a sibling file that is not explicitly imported is
+        // unreachable even though the scan has already parsed it.
+        let mut searched_uris = std::collections::HashSet::new();
+        let mut locations = Vec::new();
+
+        for (doc_uri_str, cached) in &self.cached_parses {
+            let doc_uri = match Url::parse(doc_uri_str) {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+            searched_uris.insert(doc_uri_str.clone());
+            let doc_lines: Vec<&str> = cached.source.lines().collect();
+            let defs = user_definitions_from_ast(
+                &cached.ast,
+                &cached.span_map,
+                &cached.symbol_spans,
+                &doc_lines,
+            );
+            for (name, range) in &defs {
+                if name == &symbol {
+                    if let Some(range) = range {
+                        locations.push(Location {
+                            uri: doc_uri.clone(),
+                            range: *range,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Files known only from the workspace scan (import_cache); skip files
+        // already covered above via their open-document parse.
+        for (path, import_cached) in &self.import_cache {
+            let import_uri = match Url::from_file_path(path) {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+            if searched_uris.contains(import_uri.as_str()) {
+                continue;
+            }
+            let import_lines: Vec<&str> = import_cached.source.lines().collect();
+            let defs = user_definitions_from_ast(
+                &import_cached.ast,
+                &import_cached.span_map,
+                &import_cached.symbol_spans,
+                &import_lines,
+            );
+            for (name, range) in &defs {
+                if name == &symbol {
+                    if let Some(range) = range {
+                        locations.push(Location {
+                            uri: import_uri.clone(),
+                            range: *range,
+                        });
+                    }
+                }
+            }
+        }
+
+        match locations.len() {
+            0 => None,
+            1 => Some(GotoDefinitionResponse::Scalar(locations.remove(0))),
+            // Same top-level name defined in several files: return them all
+            // (cache iteration order is arbitrary — picking one would be a
+            // coin flip; clients render an array as a location picker).
+            _ => Some(GotoDefinitionResponse::Array(locations)),
+        }
     }
 
     pub(crate) fn handle_references(&self, uri: &Url, position: &Position) -> Vec<Location> {

--- a/crates/sema-lsp/src/handlers/navigation.rs
+++ b/crates/sema-lsp/src/handlers/navigation.rs
@@ -370,10 +370,14 @@ impl BackendState {
         for (name, span) in &cached.symbol_spans {
             if name == symbol {
                 let range = span_to_range(span, &lines);
+                // End is inclusive: extract_symbol_at treats a cursor at the
+                // end of a token as on-symbol (the following char is a
+                // non-symbol char by token-boundary definition), and rename
+                // accepts that position — prepare must agree.
                 if position.line >= range.start.line
                     && position.line <= range.end.line
                     && position.character >= range.start.character
-                    && position.character < range.end.character
+                    && position.character <= range.end.character
                 {
                     return Some(PrepareRenameResponse::RangeWithPlaceholder {
                         range,

--- a/crates/sema-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/sema-lsp/src/handlers/semantic_tokens.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use tower_lsp::lsp_types::*;
 
+use crate::helpers::char_col_to_utf16;
 use crate::state::{token_modifiers, token_types, BackendState};
 
 impl BackendState {
@@ -47,7 +48,9 @@ impl BackendState {
             }
         }
 
-        let mut raw_tokens: Vec<(usize, usize, usize, u32, u32)> = Vec::new();
+        let lines: Vec<&str> = cached.source.lines().collect();
+        // (line, UTF-16 start column, UTF-16 length, token type, modifiers)
+        let mut raw_tokens: Vec<(usize, u32, usize, u32, u32)> = Vec::new();
 
         for (name, span) in &cached.symbol_spans {
             let (token_type, modifiers) = if sema_eval::SPECIAL_FORM_NAMES.contains(&name.as_str())
@@ -77,14 +80,16 @@ impl BackendState {
             if span.line != span.end_line || span.line == 0 {
                 continue;
             }
-            // Token length must be in UTF-16 code units (LSP spec), not chars.
-            // Span columns are 1-indexed char columns; sum the UTF-16 width of
-            // the chars in [col, end_col) on the token's line.
+            // Token start and length must be in UTF-16 code units (LSP spec),
+            // not chars. Span columns are 1-indexed char columns; convert the
+            // start, and sum the UTF-16 width of the chars in [col, end_col)
+            // on the token's line.
             let char_count = span.end_col.saturating_sub(span.col);
             if char_count == 0 {
                 continue;
             }
-            let length = match cached.source.lines().nth(span.line - 1) {
+            let line_text = lines.get(span.line - 1).copied();
+            let length = match line_text {
                 Some(line_text) => line_text
                     .chars()
                     .skip(span.col - 1)
@@ -93,7 +98,8 @@ impl BackendState {
                     .sum::<usize>(),
                 None => char_count,
             };
-            raw_tokens.push((span.line, span.col, length, token_type, modifiers));
+            let start = char_col_to_utf16(line_text, span.col);
+            raw_tokens.push((span.line, start, length, token_type, modifiers));
         }
 
         // Sort by position
@@ -106,7 +112,7 @@ impl BackendState {
 
         for &(line, col, length, token_type, modifiers) in &raw_tokens {
             let lsp_line = (line - 1) as u32;
-            let lsp_col = (col - 1) as u32;
+            let lsp_col = col;
 
             // Use saturating_sub to guard against underflow from unexpected
             // out-of-order spans (shouldn't happen after sort, but defensive).

--- a/crates/sema-lsp/src/handlers/structure.rs
+++ b/crates/sema-lsp/src/handlers/structure.rs
@@ -444,95 +444,186 @@ impl BackendState {
         )])
     }
 
-    /// Who calls this function: every definition whose body contains a call to `item.name`.
+    /// Collect the incoming calls to `target` found in one file's top-level
+    /// definitions (shared between open documents and scanned files).
+    fn collect_incoming_calls_in_file(
+        uri: &Url,
+        ast: &[sema_core::Value],
+        span_map: &SpanMap,
+        symbol_spans: &[(String, sema_core::Span)],
+        source: &str,
+        target: &str,
+        result: &mut Vec<CallHierarchyIncomingCall>,
+    ) {
+        let lines: Vec<&str> = source.lines().collect();
+        for expr in ast {
+            let items = match expr.as_list() {
+                Some(i) => i,
+                None => continue,
+            };
+            let (name, form_range, name_range) =
+                match def_of_form(expr, span_map, symbol_spans, &lines) {
+                    Some(d) => d,
+                    None => continue,
+                };
+            // Search only the body (skip the head + signature) to avoid matching `(name ...)`
+            // definition shorthands as calls.
+            let body: &[sema_core::Value] = items.get(2..).unwrap_or(&[]);
+            let mut sites = Vec::new();
+            collect_call_sites(body, span_map, symbol_spans, &lines, target, &mut sites);
+            if !sites.is_empty() {
+                result.push(CallHierarchyIncomingCall {
+                    from: Self::call_hierarchy_item(&name, uri, form_range, name_range),
+                    from_ranges: sites,
+                });
+            }
+        }
+    }
+
+    /// Who calls this function: every definition whose body contains a call to
+    /// `item.name`, across open documents and still-fresh scanned files.
     pub(crate) fn handle_call_hierarchy_incoming(
         &self,
         item: &CallHierarchyItem,
     ) -> Option<Vec<CallHierarchyIncomingCall>> {
         let target = &item.name;
         let mut result = Vec::new();
+        let mut open_paths: HashSet<PathBuf> = HashSet::new();
         for (uri_str, cached) in &self.cached_parses {
             let uri = match Url::parse(uri_str) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            let lines: Vec<&str> = cached.source.lines().collect();
-            for expr in &cached.ast {
-                let items = match expr.as_list() {
-                    Some(i) => i,
-                    None => continue,
-                };
-                let (name, form_range, name_range) =
-                    match def_of_form(expr, &cached.span_map, &cached.symbol_spans, &lines) {
-                        Some(d) => d,
-                        None => continue,
-                    };
-                // Search only the body (skip the head + signature) to avoid matching `(name ...)`
-                // definition shorthands as calls.
-                let body: &[sema_core::Value] = items.get(2..).unwrap_or(&[]);
-                let mut sites = Vec::new();
-                collect_call_sites(
-                    body,
-                    &cached.span_map,
-                    &cached.symbol_spans,
-                    &lines,
-                    target,
-                    &mut sites,
-                );
-                if !sites.is_empty() {
-                    result.push(CallHierarchyIncomingCall {
-                        from: Self::call_hierarchy_item(&name, &uri, form_range, name_range),
-                        from_ranges: sites,
-                    });
-                }
+            if let Ok(doc_path) = uri.to_file_path() {
+                open_paths.insert(canonicalize_or_raw(&doc_path));
             }
+            Self::collect_incoming_calls_in_file(
+                &uri,
+                &cached.ast,
+                &cached.span_map,
+                &cached.symbol_spans,
+                &cached.source,
+                target,
+                &mut result,
+            );
+        }
+        // Scanned files: dedup against open documents by canonical path and
+        // skip stale entries — same rules as references and rename.
+        for (path, import_cached) in &self.import_cache {
+            if open_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
+            let uri = match Url::from_file_path(path) {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+            Self::collect_incoming_calls_in_file(
+                &uri,
+                &import_cached.ast,
+                &import_cached.span_map,
+                &import_cached.symbol_spans,
+                &import_cached.source,
+                target,
+                &mut result,
+            );
         }
         Some(result)
     }
 
-    /// Which functions this function calls: known definitions invoked from `item.name`'s body.
+    /// The outgoing calls of `name`'s definition if this file defines it
+    /// (shared between open documents and scanned files).
+    fn outgoing_calls_of_definition(
+        name: &str,
+        ast: &[sema_core::Value],
+        span_map: &SpanMap,
+        symbol_spans: &[(String, sema_core::Span)],
+        source: &str,
+        index: &HashMap<String, (Url, Range, Range)>,
+    ) -> Option<Vec<CallHierarchyOutgoingCall>> {
+        let lines: Vec<&str> = source.lines().collect();
+        for expr in ast {
+            let items = match expr.as_list() {
+                Some(i) => i,
+                None => continue,
+            };
+            let def = match def_of_form(expr, span_map, symbol_spans, &lines) {
+                Some(d) => d,
+                None => continue,
+            };
+            if def.0 != name {
+                continue;
+            }
+            let body: &[sema_core::Value] = items.get(2..).unwrap_or(&[]);
+            let mut calls: HashMap<String, Vec<Range>> = Default::default();
+            collect_outgoing_calls(body, span_map, symbol_spans, &lines, index, &mut calls);
+            let mut out = Vec::new();
+            for (callee, sites) in calls {
+                if callee == name {
+                    continue; // skip self-recursion in outgoing view
+                }
+                if let Some((curi, crange, cname_range)) = index.get(&callee) {
+                    out.push(CallHierarchyOutgoingCall {
+                        to: Self::call_hierarchy_item(&callee, curi, *crange, *cname_range),
+                        from_ranges: sites,
+                    });
+                }
+            }
+            return Some(out);
+        }
+        None
+    }
+
+    /// Which functions this function calls: known definitions invoked from
+    /// `item.name`'s body. The definition is looked up in open documents
+    /// first, then still-fresh scanned files.
     pub(crate) fn handle_call_hierarchy_outgoing(
         &self,
         item: &CallHierarchyItem,
     ) -> Option<Vec<CallHierarchyOutgoingCall>> {
         let name = &item.name;
         let index = self.def_index();
-        for cached in self.cached_parses.values() {
-            let lines: Vec<&str> = cached.source.lines().collect();
-            for expr in &cached.ast {
-                let items = match expr.as_list() {
-                    Some(i) => i,
-                    None => continue,
-                };
-                let def = match def_of_form(expr, &cached.span_map, &cached.symbol_spans, &lines) {
-                    Some(d) => d,
-                    None => continue,
-                };
-                if &def.0 != name {
-                    continue;
+        let mut open_paths: HashSet<PathBuf> = HashSet::new();
+        let mut found: Option<Vec<CallHierarchyOutgoingCall>> = None;
+        for (uri_str, cached) in &self.cached_parses {
+            // Collect every open document's canonical path (even after a
+            // match) so the scan-cache dedup below sees the complete set.
+            if let Ok(uri) = Url::parse(uri_str) {
+                if let Ok(doc_path) = uri.to_file_path() {
+                    open_paths.insert(canonicalize_or_raw(&doc_path));
                 }
-                let body: &[sema_core::Value] = items.get(2..).unwrap_or(&[]);
-                let mut calls: std::collections::HashMap<String, Vec<Range>> = Default::default();
-                collect_outgoing_calls(
-                    body,
+            }
+            if found.is_none() {
+                found = Self::outgoing_calls_of_definition(
+                    name,
+                    &cached.ast,
                     &cached.span_map,
                     &cached.symbol_spans,
-                    &lines,
+                    &cached.source,
                     &index,
-                    &mut calls,
                 );
-                let mut out = Vec::new();
-                for (callee, sites) in calls {
-                    if callee == *name {
-                        continue; // skip self-recursion in outgoing view
-                    }
-                    if let Some((curi, crange, cname_range)) = index.get(&callee) {
-                        out.push(CallHierarchyOutgoingCall {
-                            to: Self::call_hierarchy_item(&callee, curi, *crange, *cname_range),
-                            from_ranges: sites,
-                        });
-                    }
-                }
+            }
+        }
+        if let Some(out) = found {
+            return Some(out);
+        }
+        for (path, import_cached) in &self.import_cache {
+            if open_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
+            if let Some(out) = Self::outgoing_calls_of_definition(
+                name,
+                &import_cached.ast,
+                &import_cached.span_map,
+                &import_cached.symbol_spans,
+                &import_cached.source,
+                &index,
+            ) {
                 return Some(out);
             }
         }

--- a/crates/sema-lsp/src/handlers/structure.rs
+++ b/crates/sema-lsp/src/handlers/structure.rs
@@ -73,14 +73,16 @@ impl BackendState {
     pub(crate) fn handle_workspace_symbols(&self, query: &str) -> Vec<SymbolInformation> {
         let mut results = Vec::new();
         let query_lower = query.to_lowercase();
-        let mut searched_uris: HashSet<String> = HashSet::new();
+        let mut searched_paths: HashSet<PathBuf> = HashSet::new();
 
         for (doc_uri_str, cached) in &self.cached_parses {
             let doc_uri = match Url::parse(doc_uri_str) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            searched_uris.insert(doc_uri_str.clone());
+            if let Ok(doc_path) = doc_uri.to_file_path() {
+                searched_paths.insert(canonicalize_or_raw(&doc_path));
+            }
 
             let doc_lines: Vec<&str> = self
                 .documents
@@ -111,16 +113,21 @@ impl BackendState {
             }
         }
 
-        // Also search workspace files not currently open (import_cache)
+        // Also search workspace files not currently open (import_cache).
+        // Skip files already returned via cached_parses — by canonical path,
+        // since one file may be addressed under several spellings — and
+        // entries whose on-disk file changed or vanished since the scan.
         for (path, import_cached) in &self.import_cache {
+            if searched_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
             let import_uri = match Url::from_file_path(path) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
-            // Skip files already returned via cached_parses
-            if searched_uris.contains(import_uri.as_str()) {
-                continue;
-            }
 
             let import_lines: Vec<&str> = import_cached.source.lines().collect();
             let symbols = document_symbols_from_ast(
@@ -743,7 +750,9 @@ impl BackendState {
                     Some(p) if p.exists() => p,
                     _ => continue,
                 };
-                if let Some(import_cached) = import_cache.get(&resolved) {
+                // Cache keys are canonical paths (see get_import_cache);
+                // resolve_import_path may yield an un-normalized spelling.
+                if let Some(import_cached) = import_cache.get(&canonicalize_or_raw(&resolved)) {
                     if let Some(params_str) = extract_params_from_ast(&import_cached.ast, func_name)
                     {
                         let names = parse_param_names(&params_str);

--- a/crates/sema-lsp/src/handlers/structure.rs
+++ b/crates/sema-lsp/src/handlers/structure.rs
@@ -157,6 +157,34 @@ impl BackendState {
         results
     }
 
+    /// Build the SignatureHelp for a user-defined function from its params
+    /// string (as extracted by `extract_params_from_ast`).
+    fn user_signature_help(
+        func_name: &str,
+        params_str: &str,
+        active_param: usize,
+    ) -> SignatureHelp {
+        let param_names = parse_param_names(params_str);
+        let label = format!("({func_name} {})", param_names.join(" "));
+        let parameters: Vec<ParameterInformation> = param_names
+            .iter()
+            .map(|p| ParameterInformation {
+                label: ParameterLabel::Simple(p.clone()),
+                documentation: None,
+            })
+            .collect();
+        SignatureHelp {
+            signatures: vec![SignatureInformation {
+                label,
+                documentation: None,
+                parameters: Some(parameters),
+                active_parameter: Some(active_param as u32),
+            }],
+            active_signature: Some(0),
+            active_parameter: Some(active_param as u32),
+        }
+    }
+
     pub(crate) fn handle_signature_help(
         &mut self,
         uri: &Url,
@@ -172,26 +200,11 @@ impl BackendState {
         let cached = self.cached_parses.get(uri_str)?;
 
         if let Some(params_str) = extract_params_from_ast(&cached.ast, &func_name) {
-            let param_names = parse_param_names(&params_str);
-            let label = format!("({func_name} {})", param_names.join(" "));
-            let parameters: Vec<ParameterInformation> = param_names
-                .iter()
-                .map(|p| ParameterInformation {
-                    label: ParameterLabel::Simple(p.clone()),
-                    documentation: None,
-                })
-                .collect();
-
-            return Some(SignatureHelp {
-                signatures: vec![SignatureInformation {
-                    label,
-                    documentation: None,
-                    parameters: Some(parameters),
-                    active_parameter: Some(active_param as u32),
-                }],
-                active_signature: Some(0),
-                active_parameter: Some(active_param as u32),
-            });
+            return Some(Self::user_signature_help(
+                &func_name,
+                &params_str,
+                active_param,
+            ));
         }
 
         // Try imported files
@@ -206,26 +219,11 @@ impl BackendState {
                 None => continue,
             };
             if let Some(params_str) = extract_params_from_ast(&cached.ast, &func_name) {
-                let param_names = parse_param_names(&params_str);
-                let label = format!("({func_name} {})", param_names.join(" "));
-                let parameters: Vec<ParameterInformation> = param_names
-                    .iter()
-                    .map(|p| ParameterInformation {
-                        label: ParameterLabel::Simple(p.clone()),
-                        documentation: None,
-                    })
-                    .collect();
-
-                return Some(SignatureHelp {
-                    signatures: vec![SignatureInformation {
-                        label,
-                        documentation: None,
-                        parameters: Some(parameters),
-                        active_parameter: Some(active_param as u32),
-                    }],
-                    active_signature: Some(0),
-                    active_parameter: Some(active_param as u32),
-                });
+                return Some(Self::user_signature_help(
+                    &func_name,
+                    &params_str,
+                    active_param,
+                ));
             }
         }
 
@@ -265,7 +263,17 @@ impl BackendState {
             });
         }
 
-        None
+        // Fall back to a workspace-wide search (other open documents, then
+        // still-fresh scanned files), mirroring goto-definition Phase 3d.
+        // Builtin docs outrank a workspace match — only an explicit import
+        // shadows a builtin signature.
+        let (ast, _module_name) = self.find_workspace_definition(uri, &func_name)?;
+        let params_str = extract_params_from_ast(ast, &func_name)?;
+        Some(Self::user_signature_help(
+            &func_name,
+            &params_str,
+            active_param,
+        ))
     }
 
     pub(crate) fn handle_folding_ranges(&self, uri: &Url) -> Vec<FoldingRange> {

--- a/crates/sema-lsp/src/handlers/structure.rs
+++ b/crates/sema-lsp/src/handlers/structure.rs
@@ -396,7 +396,9 @@ impl BackendState {
             };
             let form_range = span_to_range(span, &lines);
             let range = quoted_string_range(&lines, &form_range, path).unwrap_or(form_range);
-            if let Some(resolved) = resolve_import_path(uri, path) {
+            // Only link paths that resolve to an existing file (the import
+            // jump in goto-definition applies the same filter).
+            if let Some(resolved) = resolve_import_path(uri, path).filter(|p| p.exists()) {
                 if let Ok(target) = Url::from_file_path(&resolved) {
                     links.push(DocumentLink {
                         range,

--- a/crates/sema-lsp/src/handlers/structure.rs
+++ b/crates/sema-lsp/src/handlers/structure.rs
@@ -267,14 +267,16 @@ impl BackendState {
             None => return vec![],
         };
 
+        let lines: Vec<&str> = cached.source.lines().collect();
         let mut ranges = Vec::new();
-        Self::collect_folding_ranges(&cached.ast, &cached.span_map, &mut ranges);
+        Self::collect_folding_ranges(&cached.ast, &cached.span_map, &lines, &mut ranges);
         ranges
     }
 
     fn collect_folding_ranges(
         exprs: &[sema_core::Value],
         span_map: &SpanMap,
+        lines: &[&str],
         ranges: &mut Vec<FoldingRange>,
     ) {
         for expr in exprs {
@@ -284,18 +286,26 @@ impl BackendState {
                     // lines (`end_line - line >= 2`). Tiny 1-2-line forms add
                     // folding noise without any benefit.
                     if span.end_line.saturating_sub(span.line) >= 2 {
+                        // Span columns are chars; LSP characters are UTF-16
+                        // code units.
                         ranges.push(FoldingRange {
                             start_line: (span.line - 1) as u32,
-                            start_character: Some((span.col - 1) as u32),
+                            start_character: Some(char_col_to_utf16(
+                                lines.get(span.line - 1).copied(),
+                                span.col,
+                            )),
                             end_line: (span.end_line - 1) as u32,
-                            end_character: Some((span.end_col - 1) as u32),
+                            end_character: Some(char_col_to_utf16(
+                                lines.get(span.end_line - 1).copied(),
+                                span.end_col,
+                            )),
                             kind: Some(FoldingRangeKind::Region),
                             collapsed_text: None,
                         });
                     }
                 }
                 // Recurse into sub-expressions
-                Self::collect_folding_ranges(items, span_map, ranges);
+                Self::collect_folding_ranges(items, span_map, lines, ranges);
             }
         }
     }

--- a/crates/sema-lsp/src/helpers.rs
+++ b/crates/sema-lsp/src/helpers.rs
@@ -248,6 +248,18 @@ pub fn char_col_to_utf16(line: Option<&str>, col_1indexed: usize) -> u32 {
     }
 }
 
+/// Convert a 1-indexed Sema char column to a byte offset in `line` (the
+/// byte-offset sibling of [`char_col_to_utf16`], for source-scanning code
+/// that walks `char_indices`). A column past the end of the line maps to
+/// `line.len()`.
+pub(crate) fn char_col_to_byte(line: &str, col_1indexed: usize) -> usize {
+    let char_idx = col_1indexed.saturating_sub(1);
+    line.char_indices()
+        .nth(char_idx)
+        .map(|(i, _)| i)
+        .unwrap_or(line.len())
+}
+
 /// Convert a 0-indexed LSP UTF-16 `character` offset to a 1-indexed Sema char
 /// column (the inverse of [`char_col_to_utf16`]). Used when mapping an incoming
 /// editor `Position` to the column the scope/lexer machinery expects.
@@ -657,9 +669,7 @@ pub(crate) fn find_arg_positions_in_form(
 ) -> Vec<(usize, usize)> {
     let mut positions = Vec::new();
     let start_line = form_span.line.saturating_sub(1); // 0-indexed
-    let start_col = form_span.col; // 1-indexed, points at '('
     let end_line = form_span.end_line.saturating_sub(1);
-    let end_col = form_span.end_col.saturating_sub(1);
 
     // State machine to walk through the form text
     let mut depth = 0i32;
@@ -674,19 +684,26 @@ pub(crate) fn find_arg_positions_in_form(
             Some(l) => l,
             None => break,
         };
-        let col_start = if line_idx == start_line { start_col } else { 1 };
-        let col_end = if line_idx == end_line {
-            end_col + 1
+        // The scan below walks `char_indices` (byte offsets); the span's
+        // boundary columns count chars. Convert them to byte offsets so a
+        // multi-byte char earlier on the line can't desync the scan.
+        let start_byte = if line_idx == start_line {
+            char_col_to_byte(line, form_span.col) // points at '('
+        } else {
+            0
+        };
+        let end_byte = if line_idx == end_line {
+            char_col_to_byte(line, form_span.end_col) // one past ')'
         } else {
             line.len()
         };
 
         for (byte_idx, ch) in line.char_indices() {
             let col_0 = byte_idx; // 0-indexed byte position
-            if col_0 + 1 < col_start && line_idx == start_line {
+            if col_0 < start_byte && line_idx == start_line {
                 continue;
             }
-            if col_0 > col_end && line_idx == end_line {
+            if col_0 > end_byte && line_idx == end_line {
                 break;
             }
 

--- a/crates/sema-lsp/src/helpers.rs
+++ b/crates/sema-lsp/src/helpers.rs
@@ -566,6 +566,16 @@ pub fn extract_params(text: &str, name: &str) -> Option<String> {
     extract_params_from_ast(&ast, name)
 }
 
+/// Canonicalize `path`, falling back to the raw path when canonicalization
+/// fails (nonexistent file, permission error). File identity in the scan
+/// cache and the workspace-iterating handlers is canonical-path based, so
+/// one file reachable under several spellings — an un-normalized import
+/// (`a/../lib.sema`), a symlinked root (macOS `/tmp` -> `/private/tmp`), an
+/// open-document URI — maps to a single identity.
+pub(crate) fn canonicalize_or_raw(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Resolve an import/load path relative to a document URI.
 /// Returns the absolute path if resolvable.
 pub fn resolve_import_path(uri: &Url, path_str: &str) -> Option<PathBuf> {

--- a/crates/sema-lsp/src/server.rs
+++ b/crates/sema-lsp/src/server.rs
@@ -723,13 +723,36 @@ pub async fn run_server() {
     let stdout = tokio::io::stdout();
     let (stdin, mut stdin_writer) = tokio::io::duplex(64 * 1024);
 
+    // TODO(tower-lsp#399): drop this once the upstream bug is fixed.
+    // tower-lsp's `serve` future never resolves after the `exit` notification:
+    // its read loop parks on stdin (which editors hold open while waiting for
+    // the process to die), and a shutdown+exit sent back-to-back cancels the
+    // still-queued `shutdown` handler outright (`pending.cancel_all()`), so
+    // not even the force-exit watchdog armed in `Backend::shutdown` runs.
+    // The LSP spec requires `exit` to terminate the server promptly — code 0
+    // if `shutdown` was received first, 1 otherwise — so the inbound-frame
+    // normalizer watches for the lifecycle messages itself and reports `exit`
+    // here. The grace sleep lets the transport flush a pending `shutdown`
+    // response before the process goes away.
+    let (exit_tx, exit_rx) = tokio::sync::oneshot::channel::<bool>();
     tokio::spawn(async move {
-        let _ = normalize_lsp_input(raw_stdin, &mut stdin_writer).await;
+        let _ = normalize_lsp_input(raw_stdin, &mut stdin_writer, exit_tx).await;
+    });
+    tokio::spawn(async move {
+        if let Ok(shutdown_seen) = exit_rx.await {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            std::process::exit(if shutdown_seen { 0 } else { 1 });
+        }
     });
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LspRequest>();
 
     let (service, socket) = LspService::new(|client| Backend::new(client, tx.clone()));
+    // The service now owns the only senders; drop ours so the backend thread's
+    // `blocking_recv` observes channel closure (and the join below can finish)
+    // if `serve` ever returns without a `shutdown` request having been
+    // dispatched.
+    drop(tx);
 
     // Extract the client for publishing diagnostics from the backend thread.
     let client = service.inner().client.clone();
@@ -1058,7 +1081,17 @@ pub async fn run_server() {
     let _ = backend_handle.join();
 }
 
-async fn normalize_lsp_input<R, W>(mut input: R, mut output: W) -> std::io::Result<()>
+/// Copies LSP frames from `input` to `output`, normalizing each message body
+/// (the tower-lsp#399 `shutdown` params workaround) and watching for the
+/// shutdown/exit lifecycle messages. When the client sends the `exit`
+/// notification, the frame is forwarded and then `exit_signal` reports whether
+/// a `shutdown` request preceded it, so [`run_server`] can terminate the
+/// process with the spec-mandated exit code.
+async fn normalize_lsp_input<R, W>(
+    mut input: R,
+    mut output: W,
+    exit_signal: tokio::sync::oneshot::Sender<bool>,
+) -> std::io::Result<()>
 where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
@@ -1067,6 +1100,8 @@ where
 
     let mut pending = Vec::new();
     let mut chunk = [0; 8192];
+    let mut shutdown_seen = false;
+    let mut exit_signal = Some(exit_signal);
 
     loop {
         let read = input.read(&mut chunk).await?;
@@ -1096,6 +1131,10 @@ where
             pending.drain(..frame_len);
 
             let body = &frame[body_start..];
+            let method = lsp_message_method(body);
+            if method.as_deref() == Some("shutdown") {
+                shutdown_seen = true;
+            }
             let normalized = normalize_lsp_message_body(body);
             if normalized == body {
                 output.write_all(&frame).await?;
@@ -1104,8 +1143,19 @@ where
                 output.write_all(header.as_bytes()).await?;
                 output.write_all(&normalized).await?;
             }
+            if method.as_deref() == Some("exit") {
+                if let Some(signal) = exit_signal.take() {
+                    let _ = signal.send(shutdown_seen);
+                }
+            }
         }
     }
+}
+
+/// Extracts the JSON-RPC `method` from an LSP message body, if any.
+fn lsp_message_method(body: &[u8]) -> Option<String> {
+    let value = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+    Some(value.as_object()?.get("method")?.as_str()?.to_string())
 }
 
 pub(crate) fn normalize_lsp_message_body(body: &[u8]) -> Vec<u8> {

--- a/crates/sema-lsp/src/state.rs
+++ b/crates/sema-lsp/src/state.rs
@@ -508,19 +508,53 @@ impl BackendState {
         None
     }
 
-    /// Index every top-level definition across open documents: name → (uri, form range, name range).
+    /// Index every top-level definition across open documents and still-fresh
+    /// scanned workspace files: name → (uri, form range, name range). Open
+    /// documents are inserted first, so they win over a scanned entry for the
+    /// same name (`or_insert`); scan entries are dedup'd against open
+    /// documents by canonical path, same rules as references and rename.
     pub(crate) fn def_index(&self) -> std::collections::HashMap<String, (Url, Range, Range)> {
         let mut index = std::collections::HashMap::new();
+        let mut open_paths: HashSet<PathBuf> = HashSet::new();
         for (uri_str, cached) in &self.cached_parses {
             let uri = match Url::parse(uri_str) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
+            if let Ok(doc_path) = uri.to_file_path() {
+                open_paths.insert(canonicalize_or_raw(&doc_path));
+            }
             let lines: Vec<&str> = cached.source.lines().collect();
             for expr in &cached.ast {
                 if let Some((name, form_range, name_range)) =
                     def_of_form(expr, &cached.span_map, &cached.symbol_spans, &lines)
                 {
+                    index
+                        .entry(name)
+                        .or_insert((uri.clone(), form_range, name_range));
+                }
+            }
+        }
+
+        for (path, import_cached) in &self.import_cache {
+            if open_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
+            let uri = match Url::from_file_path(path) {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+            let lines: Vec<&str> = import_cached.source.lines().collect();
+            for expr in &import_cached.ast {
+                if let Some((name, form_range, name_range)) = def_of_form(
+                    expr,
+                    &import_cached.span_map,
+                    &import_cached.symbol_spans,
+                    &lines,
+                ) {
                     index
                         .entry(name)
                         .or_insert((uri.clone(), form_range, name_range));

--- a/crates/sema-lsp/src/state.rs
+++ b/crates/sema-lsp/src/state.rs
@@ -62,12 +62,14 @@ impl WorkspaceScanner {
             if name_str.starts_with('.') || name_str == "target" || name_str == "node_modules" {
                 continue;
             }
-            // Follow symlinks for file discovery; cycles are detected via canonicalize + visited set
-            let meta = match entry.metadata() {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
+            // Type-check through symlinks (`DirEntry::metadata` does not
+            // traverse them, which would skip symlinked dirs and files);
+            // cycles are prevented by the canonical-path visited set below.
             let path = entry.path();
+            let meta = match std::fs::metadata(&path) {
+                Ok(m) => m,
+                Err(_) => continue, // broken symlink or unreadable
+            };
             if meta.is_dir() {
                 if let Ok(canonical) = std::fs::canonicalize(&path) {
                     if self.visited.insert(canonical) {

--- a/crates/sema-lsp/src/state.rs
+++ b/crates/sema-lsp/src/state.rs
@@ -97,6 +97,21 @@ pub(crate) struct ImportCache {
     pub(crate) mtime: std::time::SystemTime,
 }
 
+impl ImportCache {
+    /// Whether this entry still matches the file on disk. Handlers that
+    /// iterate the cache directly (references, rename, workspace symbols,
+    /// the goto-definition workspace fallback) must skip entries that are
+    /// not fresh: their spans index content that no longer exists, and a
+    /// rename edit built from them would corrupt the file. Missing metadata
+    /// counts as stale — a deleted file has nothing to point into.
+    pub(crate) fn is_fresh(&self, path: &Path) -> bool {
+        std::fs::metadata(path)
+            .and_then(|m| m.modified())
+            .map(|mtime| mtime == self.mtime)
+            .unwrap_or(false)
+    }
+}
+
 /// Cached parse result for an open document (updated on every didChange).
 pub(crate) struct CachedParse {
     pub(crate) ast: Vec<sema_core::Value>,
@@ -359,12 +374,25 @@ impl BackendState {
 
     /// Get or refresh the cached parse result for an imported file.
     pub(crate) fn get_import_cache(&mut self, path: &Path) -> Option<&ImportCache> {
-        let mtime = std::fs::metadata(path).and_then(|m| m.modified()).ok()?;
+        // One canonical key per file: import resolution yields un-normalized
+        // paths (`a/../lib.sema`), and clients may address a file through a
+        // symlinked root; distinct keys for the same file would duplicate
+        // results in every handler that iterates this map.
+        let path = canonicalize_or_raw(path);
+        let mtime = match std::fs::metadata(&path).and_then(|m| m.modified()) {
+            Ok(mtime) => mtime,
+            Err(_) => {
+                // File deleted or unreadable — drop any stale entry so the
+                // iterating handlers stop seeing it.
+                self.import_cache.remove(&path);
+                return None;
+            }
+        };
 
         // Check if cache is still valid
-        if let Some(cached) = self.import_cache.get(path) {
+        if let Some(cached) = self.import_cache.get(&path) {
             if cached.mtime == mtime {
-                return self.import_cache.get(path);
+                return self.import_cache.get(&path);
             }
         }
 
@@ -382,15 +410,24 @@ impl BackendState {
             }
         }
 
-        // Read and parse the file
-        let text = std::fs::read_to_string(path).ok()?;
-        let (ast, span_map, symbol_spans) = sema_reader::read_many_with_symbol_spans(&text).ok()?;
+        // Read and parse the file. On failure, drop any previously cached
+        // entry: it describes content that is gone, and serving it to the
+        // iterating handlers would point them at stale offsets.
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            self.import_cache.remove(&path);
+            return None;
+        };
+        let Ok((ast, span_map, symbol_spans)) = sema_reader::read_many_with_symbol_spans(&text)
+        else {
+            self.import_cache.remove(&path);
+            return None;
+        };
         // Drop quoted (data) symbol occurrences (see filter_quoted_symbol_spans).
         let symbol_spans = filter_quoted_symbol_spans(&ast, &span_map, symbol_spans);
         let scope_tree = scope::ScopeTree::build(&ast, &span_map, &symbol_spans);
 
         self.import_cache.insert(
-            path.to_path_buf(),
+            path.clone(),
             ImportCache {
                 ast,
                 span_map,
@@ -400,7 +437,7 @@ impl BackendState {
                 mtime,
             },
         );
-        self.import_cache.get(path)
+        self.import_cache.get(&path)
     }
 
     /// Index every top-level definition across open documents: name → (uri, form range, name range).

--- a/crates/sema-lsp/src/state.rs
+++ b/crates/sema-lsp/src/state.rs
@@ -442,6 +442,72 @@ impl BackendState {
         self.import_cache.get(&path)
     }
 
+    /// Search the whole workspace for a top-level definition of `symbol`:
+    /// other open documents first, then still-fresh scanned files (dedup'd
+    /// against open documents by canonical path — same rules as references
+    /// and rename). Skips `current_uri`: its definitions were already
+    /// consulted by the caller. Returns the defining file's AST (for
+    /// signature/docstring extraction) plus a short display name (file stem)
+    /// for attribution.
+    pub(crate) fn find_workspace_definition(
+        &self,
+        current_uri: &Url,
+        symbol: &str,
+    ) -> Option<(&[sema_core::Value], String)> {
+        let mut open_paths: HashSet<PathBuf> = HashSet::new();
+        let mut found: Option<(&[sema_core::Value], String)> = None;
+        for (doc_uri_str, cached) in &self.cached_parses {
+            // Collect every open document's canonical path (even after a
+            // match) so the scan-cache dedup below sees the complete set.
+            if let Ok(doc_uri) = Url::parse(doc_uri_str) {
+                if let Ok(doc_path) = doc_uri.to_file_path() {
+                    open_paths.insert(canonicalize_or_raw(&doc_path));
+                }
+            }
+            if found.is_some() || doc_uri_str == current_uri.as_str() {
+                continue;
+            }
+            // Names only; ranges discarded — &[] skips UTF-16 mapping.
+            let defs =
+                user_definitions_from_ast(&cached.ast, &cached.span_map, &cached.symbol_spans, &[]);
+            if defs.iter().any(|(name, _)| name == symbol) {
+                let stem = Path::new(doc_uri_str)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(doc_uri_str)
+                    .to_string();
+                found = Some((&cached.ast, stem));
+            }
+        }
+        if found.is_some() {
+            return found;
+        }
+
+        for (path, import_cached) in &self.import_cache {
+            if open_paths.contains(&canonicalize_or_raw(path)) {
+                continue;
+            }
+            if !import_cached.is_fresh(path) {
+                continue;
+            }
+            let defs = user_definitions_from_ast(
+                &import_cached.ast,
+                &import_cached.span_map,
+                &import_cached.symbol_spans,
+                &[],
+            );
+            if defs.iter().any(|(name, _)| name == symbol) {
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+                    .to_string();
+                return Some((&import_cached.ast, stem));
+            }
+        }
+        None
+    }
+
     /// Index every top-level definition across open documents: name → (uri, form range, name range).
     pub(crate) fn def_index(&self) -> std::collections::HashMap<String, (Url, Range, Range)> {
         let mut index = std::collections::HashMap::new();

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1952,6 +1952,78 @@ fn completion_works_on_trailing_empty_line_after_newline() {
     );
 }
 
+// ── call hierarchy across scanned files ──────────────────────
+
+#[test]
+fn call_hierarchy_incoming_finds_caller_in_scanned_file() {
+    // `helper` is defined in the open document; its only caller lives in a
+    // scanned (never-opened) workspace file.
+    let dir = unique_temp_dir("ch-incoming");
+    let caller_path = dir.join("main.sema");
+    let (mut state, uri) = parsed_state("file:///ws/lib.sema", "(defun helper (x) (* x x))");
+    insert_scanned_file(&mut state, &caller_path, "(defun main () (helper 5))\n");
+
+    let item = state
+        .handle_call_hierarchy_prepare(
+            &uri,
+            &Position {
+                line: 0,
+                character: 8,
+            },
+        )
+        .expect("prepare")
+        .remove(0);
+    let incoming = state
+        .handle_call_hierarchy_incoming(&item)
+        .expect("incoming");
+    assert_eq!(
+        incoming.len(),
+        1,
+        "the caller in the scanned file must be found: {incoming:?}"
+    );
+    assert_eq!(incoming[0].from.name, "main");
+    assert_eq!(
+        incoming[0].from.uri,
+        Url::from_file_path(&caller_path).unwrap()
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn call_hierarchy_outgoing_finds_callee_in_scanned_file() {
+    // `main` (open) calls `helper`, which is defined only in a scanned file.
+    let dir = unique_temp_dir("ch-outgoing");
+    let callee_path = dir.join("lib.sema");
+    let (mut state, uri) = parsed_state("file:///ws/main.sema", "(defun main () (helper 5))");
+    insert_scanned_file(&mut state, &callee_path, "(defun helper (x) (* x x))\n");
+
+    let item = state
+        .handle_call_hierarchy_prepare(
+            &uri,
+            &Position {
+                line: 0,
+                character: 8,
+            },
+        )
+        .expect("prepare")
+        .remove(0);
+    assert_eq!(item.name, "main");
+    let outgoing = state
+        .handle_call_hierarchy_outgoing(&item)
+        .expect("outgoing");
+    assert_eq!(
+        outgoing.len(),
+        1,
+        "the callee defined in the scanned file must be found: {outgoing:?}"
+    );
+    assert_eq!(outgoing[0].to.name, "helper");
+    assert_eq!(
+        outgoing[0].to.uri,
+        Url::from_file_path(&callee_path).unwrap()
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // ── hover / signature help: workspace-wide fallback ──────────
 
 #[test]

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1868,6 +1868,30 @@ fn references_top_level_skips_shadowing_param() {
     );
 }
 
+// prepare_rename must accept the cursor sitting at the END of a symbol:
+// extract_symbol_at (and therefore rename itself) treats end-of-token as
+// on-symbol, and prepare/rename must agree or the client aborts the rename.
+#[test]
+fn prepare_rename_accepts_cursor_at_symbol_end() {
+    let (state, uri) = parsed_state("file:///pr.sema", "(define foo 1)");
+    // `foo` spans characters 8..11; position 11 is just after its last char.
+    let response = state
+        .handle_prepare_rename(
+            &uri,
+            &Position {
+                line: 0,
+                character: 11,
+            },
+        )
+        .expect("prepare_rename must accept the cursor at the symbol's end");
+    match response {
+        PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. } => {
+            assert_eq!(placeholder, "foo");
+        }
+        other => panic!("expected a range with placeholder, got {other:?}"),
+    }
+}
+
 #[test]
 fn navigation_handlers_tolerate_past_eof_and_unopened_uri() {
     // Graceful degradation: a position past EOF and a never-opened URI must not panic.

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1952,6 +1952,97 @@ fn completion_works_on_trailing_empty_line_after_newline() {
     );
 }
 
+// ── hover / signature help: workspace-wide fallback ──────────
+
+#[test]
+fn hover_finds_definition_in_scanned_workspace_file() {
+    let dir = unique_temp_dir("hover-ws");
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_scanned_file(
+        &mut state,
+        &dir.join("library.sema"),
+        "(define (greet name) name)\n",
+    );
+
+    let hover = state
+        .handle_hover(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("hover must fall back to the workspace definition");
+    let HoverContents::Markup(content) = hover.contents else {
+        panic!("expected markdown hover");
+    };
+    // Params render with their list parens, matching the current-doc and
+    // "Imported from" hover branches.
+    assert!(
+        content.value.contains("(greet (name))"),
+        "hover must show the signature: {}",
+        content.value
+    );
+    assert!(
+        content.value.contains("*Defined in `library`*"),
+        "a workspace match is attributed to its file, not an import: {}",
+        content.value
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn hover_finds_definition_in_other_open_document() {
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_parsed_doc(
+        &mut state,
+        "file:///ws/library.sema",
+        "(define (greet name) name)\n",
+    );
+
+    let hover = state
+        .handle_hover(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("hover must fall back to other open documents");
+    let HoverContents::Markup(content) = hover.contents else {
+        panic!("expected markdown hover");
+    };
+    assert!(
+        content.value.contains("*Defined in `library`*"),
+        "got: {}",
+        content.value
+    );
+}
+
+#[test]
+fn signature_help_finds_definition_in_scanned_workspace_file() {
+    let dir = unique_temp_dir("sig-ws");
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet x)\n");
+    insert_scanned_file(
+        &mut state,
+        &dir.join("library.sema"),
+        "(define (greet name) name)\n",
+    );
+
+    let help = state
+        .handle_signature_help(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 7,
+            },
+        )
+        .expect("signature help must fall back to the workspace definition");
+    assert_eq!(help.signatures.len(), 1);
+    assert_eq!(help.signatures[0].label, "(greet name)");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // ── workspace scanner ────────────────────────────────────────
 
 /// The scanner must follow symlinked directories and files (DirEntry

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1936,6 +1936,44 @@ fn completion_works_on_trailing_empty_line_after_newline() {
     );
 }
 
+// ── workspace scanner ────────────────────────────────────────
+
+/// The scanner must follow symlinked directories and files (DirEntry
+/// metadata does not traverse symlinks); the canonical-path visited set is
+/// what protects it from symlink cycles.
+#[cfg(unix)]
+#[test]
+fn workspace_scanner_follows_symlinks_without_cycling() {
+    let dir = unique_temp_dir("scan-symlink");
+    let real = dir.join("real");
+    std::fs::create_dir_all(&real).unwrap();
+    std::fs::write(real.join("lib.sema"), "(define x 1)\n").unwrap();
+    let root = dir.join("root");
+    std::fs::create_dir_all(&root).unwrap();
+    // A symlinked directory, a symlinked file, and a cycle back to the root.
+    std::os::unix::fs::symlink(&real, root.join("linked")).unwrap();
+    std::os::unix::fs::symlink(real.join("lib.sema"), root.join("alias.sema")).unwrap();
+    std::os::unix::fs::symlink(&root, real.join("back")).unwrap();
+
+    let mut scanner = crate::state::WorkspaceScanner::new(&root);
+    let mut files = Vec::new();
+    while let Some(batch) = scanner.next_dir() {
+        files.extend(batch);
+    }
+
+    assert!(
+        files
+            .iter()
+            .any(|f| f.file_name().and_then(|n| n.to_str()) == Some("alias.sema")),
+        "symlinked .sema files must be discovered: {files:?}"
+    );
+    assert!(
+        files.iter().any(|f| f.ends_with("linked/lib.sema")),
+        "files inside symlinked directories must be discovered: {files:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // ── goto-definition: workspace-wide fallback (Phase 3d) ──────
 
 /// Parse `source` and insert it into `state` as an open document, mirroring

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1407,6 +1407,21 @@ fn arg_positions_with_comment() {
     assert_eq!(positions[1], (1, 2)); // 'b'
 }
 
+#[test]
+fn arg_positions_after_astral_char_on_line() {
+    // The scan works in bytes (char_indices); the span's boundary columns
+    // count chars. With a 🎉 (4 UTF-8 bytes, 1 char) before the nested form,
+    // an unconverted boundary makes the scan start inside the string literal
+    // and desync its string-state machine, dropping every argument position.
+    let text = "(fmt \"🎉\" (add 1 2))";
+    let lines: Vec<&str> = text.lines().collect();
+    // Inner `(add 1 2)`: `(` at char col 10, one-past-`)` at char col 19.
+    let span = sema_core::Span::new(1, 10, 1, 19);
+    let positions = find_arg_positions_in_form(&span, &lines, 2);
+    // `1` at byte 17, `2` at byte 19.
+    assert_eq!(positions, vec![(0, 17), (0, 19)]);
+}
+
 // ── top_level_ranges ─────────────────────────────────────────
 
 #[test]
@@ -1643,6 +1658,36 @@ fn inlay_hint_arg_position_uses_utf16_after_emoji() {
         b_hint.position.character, 8,
         "arg position must be a UTF-16 column, not a byte offset"
     );
+}
+
+// Inlay parameter hints must survive astral chars in an earlier argument:
+// the argument scan compares byte offsets from `char_indices` against the
+// form span's boundary columns, which count chars — the byte overshoot from
+// the astral chars made the scan break before reaching the later arguments.
+#[test]
+fn inlay_hints_survive_astral_chars_in_earlier_argument() {
+    let src = "(defun f (a b) a)\n(f \"🎉🎉\" x)";
+    let (mut state, uri) = parsed_state("file:///inlay2.sema", src);
+    let full = Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 10,
+            character: 0,
+        },
+    };
+    let hints = state
+        .handle_inlay_hints(&uri, &full)
+        .expect("hints for the (f ...) call");
+    let b_hint = hints
+        .iter()
+        .find(|h| matches!(&h.label, InlayHintLabel::String(s) if s == "b:"))
+        .expect("expected a `b:` inlay hint for the argument after the 🎉🎉 string");
+    assert_eq!(b_hint.position.line, 1);
+    // `x` is at UTF-16 column 10 (each 🎉 counts as 2 units).
+    assert_eq!(b_hint.position.character, 10);
 }
 
 // LSP-2: semantic-token length must be in UTF-16 code units. A user-defined

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1952,6 +1952,121 @@ fn completion_works_on_trailing_empty_line_after_newline() {
     );
 }
 
+// ── completion: cross-file user symbols ──────────────────────
+
+#[test]
+fn completion_offers_symbols_from_scanned_workspace_files() {
+    let dir = unique_temp_dir("comp-ws");
+    let (mut state, uri) = parsed_state("file:///ws/main.sema", "(define x 1)\n");
+    insert_scanned_file(
+        &mut state,
+        &dir.join("library.sema"),
+        "(define (greet name) name)\n",
+    );
+
+    let items = state.handle_complete(
+        &uri,
+        &Position {
+            line: 1,
+            character: 0,
+        },
+    );
+    let greet = items
+        .iter()
+        .find(|i| i.label == "greet")
+        .expect("scanned-file symbol must be offered");
+    assert_eq!(greet.kind, Some(CompletionItemKind::FUNCTION));
+    assert_eq!(
+        greet.detail.as_deref(),
+        Some("(name)"),
+        "params from the scanned definition must surface as detail"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn completion_dedups_scanned_symbols_against_open_document() {
+    // The same name defined in the open document and in a scanned file must
+    // yield one item — the open document's.
+    let dir = unique_temp_dir("comp-dedup");
+    let source = "(define (greet name) name)\n";
+    let (mut state, uri) = parsed_state("file:///ws/main.sema", source);
+    state
+        .cached_user_defs
+        .insert(uri.as_str().to_string(), vec!["greet".to_string()]);
+    insert_scanned_file(&mut state, &dir.join("library.sema"), source);
+
+    let items = state.handle_complete(
+        &uri,
+        &Position {
+            line: 1,
+            character: 0,
+        },
+    );
+    let greet_items: Vec<_> = items.iter().filter(|i| i.label == "greet").collect();
+    assert_eq!(
+        greet_items.len(),
+        1,
+        "open-document definition must win: {greet_items:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn completion_prefers_builtins_over_scanned_symbols() {
+    let dir = unique_temp_dir("comp-builtin");
+    let (mut state, uri) = parsed_state("file:///ws/main.sema", "(define x 1)\n");
+    state.builtin_names.insert("greet".to_string());
+    insert_scanned_file(
+        &mut state,
+        &dir.join("library.sema"),
+        "(define (greet name) name)\n",
+    );
+
+    let items = state.handle_complete(
+        &uri,
+        &Position {
+            line: 1,
+            character: 0,
+        },
+    );
+    let greet_items: Vec<_> = items.iter().filter(|i| i.label == "greet").collect();
+    assert_eq!(greet_items.len(), 1, "builtin must win: {greet_items:?}");
+    assert!(
+        greet_items[0].data.is_none(),
+        "the surviving item must be the builtin (no uri payload), got {:?}",
+        greet_items[0]
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn completion_resolve_enriches_scanned_file_definition() {
+    let dir = unique_temp_dir("comp-resolve");
+    let mut state = BackendState::new_without_builtins(HashMap::new(), "sema".to_string());
+    insert_scanned_file(
+        &mut state,
+        &dir.join("library.sema"),
+        "(defun greet (name)\n  \"Say hello.\"\n  name)\n",
+    );
+
+    let item = CompletionItem {
+        label: "greet".to_string(),
+        kind: Some(CompletionItemKind::FUNCTION),
+        ..Default::default()
+    };
+    let resolved = state.handle_completion_resolve(item);
+    let doc = match resolved.documentation {
+        Some(Documentation::MarkupContent(c)) => c.value,
+        other => panic!("expected markdown documentation, got {other:?}"),
+    };
+    // The resolve path renders the flattened signature form (see
+    // user_definition_signature), unlike hover's raw-params form.
+    assert!(doc.contains("(greet name)"), "got: {doc}");
+    assert!(doc.contains("Say hello."), "got: {doc}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // ── call hierarchy across scanned files ──────────────────────
 
 #[test]

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1933,23 +1933,49 @@ fn insert_parsed_doc(state: &mut BackendState, uri: &str, source: &str) {
     state.documents.insert(uri.to_string(), source.to_string());
 }
 
-/// Parse `source` and insert it into `state.import_cache` under `path`,
-/// as the post-`initialized` workspace scan does for unopened files.
-fn insert_scanned_file(state: &mut BackendState, path: &str, source: &str) {
+/// Unique per-test temp dir, canonicalized so expected URIs stay stable on
+/// platforms where the temp root is itself a symlink (macOS `/var`).
+fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    let dir =
+        std::env::temp_dir().join(format!("sema-lsp-{prefix}-{}-{nanos}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::canonicalize(&dir).unwrap()
+}
+
+/// Write `source` to `path`, parse it, and insert it into
+/// `state.import_cache` keyed by `path` with the file's real mtime — as the
+/// post-`initialized` workspace scan does for unopened files. The file must
+/// be real: handlers that iterate the cache skip entries whose on-disk file
+/// is missing or has a different mtime.
+fn insert_scanned_file(state: &mut BackendState, path: &std::path::Path, source: &str) {
+    std::fs::write(path, source).unwrap();
+    let mtime = std::fs::metadata(path).and_then(|m| m.modified()).unwrap();
     let (ast, span_map, symbol_spans) = sema_reader::read_many_with_symbol_spans(source).unwrap();
     let symbol_spans = crate::helpers::filter_quoted_symbol_spans(&ast, &span_map, symbol_spans);
     let scope_tree = scope::ScopeTree::build(&ast, &span_map, &symbol_spans);
     state.import_cache.insert(
-        std::path::PathBuf::from(path),
+        path.to_path_buf(),
         crate::state::ImportCache {
             ast,
             span_map,
             symbol_spans,
             scope_tree,
             source: source.to_string(),
-            mtime: std::time::SystemTime::now(),
+            mtime,
         },
     );
+}
+
+/// Push `path`'s mtime into the future so it no longer matches the mtime a
+/// scan-cache entry recorded (deterministic regardless of mtime granularity).
+fn bump_mtime(path: &std::path::Path) {
+    let file = std::fs::File::options().write(true).open(path).unwrap();
+    file.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(5))
+        .unwrap();
 }
 
 #[test]
@@ -1986,12 +2012,10 @@ fn goto_definition_finds_symbol_in_other_open_document() {
 fn goto_definition_finds_symbol_in_scanned_workspace_file() {
     // The defining file was discovered by the workspace scan but never opened:
     // it exists only in import_cache. No import statement links the two files.
+    let dir = unique_temp_dir("goto-scan");
+    let library = dir.join("library.sema");
     let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
-    insert_scanned_file(
-        &mut state,
-        "/ws/library.sema",
-        "(define (greet name) name)\n",
-    );
+    insert_scanned_file(&mut state, &library, "(define (greet name) name)\n");
 
     let result = state
         .handle_goto_definition(
@@ -2004,20 +2028,24 @@ fn goto_definition_finds_symbol_in_scanned_workspace_file() {
         .expect("expected a definition from the workspace scan cache");
     match result {
         GotoDefinitionResponse::Scalar(location) => {
-            assert_eq!(location.uri.as_str(), "file:///ws/library.sema");
+            assert_eq!(location.uri, Url::from_file_path(&library).unwrap());
             assert_eq!(location.range.start.line, 0);
         }
         other => panic!("expected a scalar location, got {other:?}"),
     }
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]
 fn goto_definition_returns_all_candidates_when_name_defined_in_multiple_files() {
     // Two workspace files both define `greet`: cache iteration order is
     // arbitrary, so the handler must return every candidate, not a coin flip.
+    let dir = unique_temp_dir("goto-multi");
+    let file_a = dir.join("a.sema");
+    let file_b = dir.join("b.sema");
     let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
-    insert_scanned_file(&mut state, "/ws/a.sema", "(define (greet name) name)\n");
-    insert_scanned_file(&mut state, "/ws/b.sema", "(define (greet name) 42)\n");
+    insert_scanned_file(&mut state, &file_a, "(define (greet name) name)\n");
+    insert_scanned_file(&mut state, &file_b, "(define (greet name) 42)\n");
 
     let result = state
         .handle_goto_definition(
@@ -2032,26 +2060,32 @@ fn goto_definition_returns_all_candidates_when_name_defined_in_multiple_files() 
         GotoDefinitionResponse::Array(mut locations) => {
             locations.sort_by(|a, b| a.uri.as_str().cmp(b.uri.as_str()));
             let uris: Vec<&str> = locations.iter().map(|l| l.uri.as_str()).collect();
-            assert_eq!(uris, vec!["file:///ws/a.sema", "file:///ws/b.sema"]);
+            let mut expected = [
+                Url::from_file_path(&file_a).unwrap(),
+                Url::from_file_path(&file_b).unwrap(),
+            ];
+            expected.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+            let expected: Vec<&str> = expected.iter().map(|u| u.as_str()).collect();
+            assert_eq!(uris, expected);
         }
         other => panic!("expected an array of locations, got {other:?}"),
     }
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]
 fn goto_definition_skips_scan_cache_entry_for_open_document() {
     // A file that is both open (cached_parses) and in the scan cache must not
     // yield two locations for its single definition.
+    let dir = unique_temp_dir("goto-dedup");
+    let library = dir.join("library.sema");
+    let source = "(define (greet name) name)\n";
     let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_scanned_file(&mut state, &library, source);
     insert_parsed_doc(
         &mut state,
-        "file:///ws/library.sema",
-        "(define (greet name) name)\n",
-    );
-    insert_scanned_file(
-        &mut state,
-        "/ws/library.sema",
-        "(define (greet name) name)\n",
+        Url::from_file_path(&library).unwrap().as_str(),
+        source,
     );
 
     let result = state
@@ -2067,17 +2101,87 @@ fn goto_definition_skips_scan_cache_entry_for_open_document() {
         matches!(result, GotoDefinitionResponse::Scalar(_)),
         "open-document and scan-cache copies of the same file must dedup, got {result:?}"
     );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The same file addressed through a symlink by the editor and through its
+/// real path by the workspace scan is still one file: dedup must compare
+/// canonical paths, not URI strings.
+#[cfg(unix)]
+#[test]
+fn goto_definition_dedups_symlinked_open_document_against_scan_entry() {
+    let dir = unique_temp_dir("goto-symlink");
+    let real = dir.join("library.sema");
+    let link = dir.join("link.sema");
+    let source = "(define (greet name) name)\n";
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_scanned_file(&mut state, &real, source);
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    insert_parsed_doc(
+        &mut state,
+        Url::from_file_path(&link).unwrap().as_str(),
+        source,
+    );
+
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("expected exactly one definition");
+    assert!(
+        matches!(result, GotoDefinitionResponse::Scalar(_)),
+        "symlinked open document and scan entry are one file, got {result:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn goto_definition_skips_stale_and_deleted_scan_cache_entries() {
+    // Scan entries whose on-disk file was modified or deleted since parsing
+    // have stale spans; only the still-fresh file may answer.
+    let dir = unique_temp_dir("goto-stale");
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    let fresh = dir.join("fresh.sema");
+    insert_scanned_file(&mut state, &fresh, "(define (greet name) name)\n");
+    let stale = dir.join("stale.sema");
+    insert_scanned_file(&mut state, &stale, "(define (greet name) 1)\n");
+    bump_mtime(&stale);
+    let deleted = dir.join("deleted.sema");
+    insert_scanned_file(&mut state, &deleted, "(define (greet name) 2)\n");
+    std::fs::remove_file(&deleted).unwrap();
+
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("expected the fresh definition");
+    match result {
+        GotoDefinitionResponse::Scalar(location) => {
+            assert_eq!(location.uri, Url::from_file_path(&fresh).unwrap());
+        }
+        other => panic!("stale/deleted scan entries must be skipped, got {other:?}"),
+    }
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]
 fn goto_definition_still_prefers_local_scope_over_workspace() {
     // A locally-bound `greet` must resolve to the local binding (Phase 3b),
     // not fall through to a same-named definition elsewhere in the workspace.
+    let dir = unique_temp_dir("goto-local");
     let source = "(define (run) (let ((greet 1)) (greet)))\n";
     let (mut state, main_uri) = parsed_state("file:///ws/main.sema", source);
     insert_scanned_file(
         &mut state,
-        "/ws/library.sema",
+        &dir.join("library.sema"),
         "(define (greet name) name)\n",
     );
 
@@ -2102,4 +2206,235 @@ fn goto_definition_still_prefers_local_scope_over_workspace() {
         }
         other => panic!("expected a scalar location, got {other:?}"),
     }
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ── scan-cache identity and invalidation ─────────────────────
+
+#[test]
+fn get_import_cache_uses_one_key_per_file() {
+    // resolve_import_path yields un-normalized paths (`a/../lib.sema`); the
+    // same file must not occupy two cache keys.
+    let dir = unique_temp_dir("cache-canon");
+    std::fs::create_dir_all(dir.join("a")).unwrap();
+    std::fs::write(dir.join("lib.sema"), "(define x 1)\n").unwrap();
+    let mut state = BackendState::new_without_builtins(HashMap::new(), "sema".to_string());
+
+    let indirect = dir.join("a").join("..").join("lib.sema");
+    assert!(state.get_import_cache(&indirect).is_some());
+    assert!(state.get_import_cache(&dir.join("lib.sema")).is_some());
+    assert_eq!(
+        state.import_cache.len(),
+        1,
+        "one file must occupy one cache key"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn get_import_cache_evicts_entry_for_deleted_file() {
+    let dir = unique_temp_dir("cache-deleted");
+    let path = dir.join("lib.sema");
+    std::fs::write(&path, "(define x 1)\n").unwrap();
+    let mut state = BackendState::new_without_builtins(HashMap::new(), "sema".to_string());
+    assert!(state.get_import_cache(&path).is_some());
+    assert_eq!(state.import_cache.len(), 1);
+
+    std::fs::remove_file(&path).unwrap();
+    assert!(state.get_import_cache(&path).is_none());
+    assert!(
+        state.import_cache.is_empty(),
+        "the entry for a deleted file must be evicted"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn get_import_cache_evicts_entry_when_reparse_fails() {
+    let dir = unique_temp_dir("cache-reparse");
+    let path = dir.join("lib.sema");
+    std::fs::write(&path, "(define x 1)\n").unwrap();
+    let mut state = BackendState::new_without_builtins(HashMap::new(), "sema".to_string());
+    assert!(state.get_import_cache(&path).is_some());
+
+    // Replace with unparseable content at a different mtime.
+    std::fs::write(&path, "(define x").unwrap();
+    bump_mtime(&path);
+    assert!(state.get_import_cache(&path).is_none());
+    assert!(
+        state.import_cache.is_empty(),
+        "the entry for a file that no longer parses must be evicted"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Build a state with `lib.sema` on disk (in the scan cache) and the same
+/// file open in the editor through a symlink. The two spellings are one
+/// file; handlers that merge open documents with the scan cache must not
+/// produce doubled results for it.
+#[cfg(unix)]
+fn symlinked_open_and_scanned_state(
+    prefix: &str,
+    source: &str,
+) -> (BackendState, Url, std::path::PathBuf) {
+    let dir = unique_temp_dir(prefix);
+    let real = dir.join("lib.sema");
+    let link = dir.join("link.sema");
+    let mut state = BackendState::new_without_builtins(HashMap::new(), "sema".to_string());
+    insert_scanned_file(&mut state, &real, source);
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let link_uri = Url::from_file_path(&link).unwrap();
+    insert_parsed_doc(&mut state, link_uri.as_str(), source);
+    (state, link_uri, dir)
+}
+
+#[cfg(unix)]
+#[test]
+fn references_dedup_symlinked_open_document_against_scan_entry() {
+    let (state, link_uri, dir) =
+        symlinked_open_and_scanned_state("refs-canon", "(define foo 1)\n(+ foo 1)\n");
+    let refs = state.handle_references(
+        &link_uri,
+        &Position {
+            line: 0,
+            character: 8,
+        },
+    );
+    assert_eq!(
+        refs.len(),
+        2,
+        "the symlinked open document and the scan entry are one file: {refs:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn rename_does_not_emit_duplicate_edits_for_symlinked_file() {
+    // Duplicate edits for one file under two URIs would each be applied by
+    // the client — corrupting the file.
+    let (state, link_uri, dir) =
+        symlinked_open_and_scanned_state("rename-canon", "(define foo 1)\n(+ foo 1)\n");
+    let edit = state
+        .handle_rename(
+            &link_uri,
+            &Position {
+                line: 0,
+                character: 8,
+            },
+            "bar",
+        )
+        .expect("rename should produce edits");
+    let changes = edit.changes.expect("changes");
+    assert_eq!(
+        changes.len(),
+        1,
+        "one file must receive one set of edits: {changes:?}"
+    );
+    assert_eq!(changes[&link_uri].len(), 2);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn workspace_symbols_dedup_symlinked_open_document_against_scan_entry() {
+    let (state, _link_uri, dir) =
+        symlinked_open_and_scanned_state("symbols-canon", "(define foo 1)\n");
+    let results = state.handle_workspace_symbols("foo");
+    assert_eq!(
+        results.len(),
+        1,
+        "one definition must yield one workspace symbol: {results:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Build a state with a `main.sema` open document plus three scanned files:
+/// one fresh, one whose mtime changed after the scan, one deleted since.
+fn state_with_fresh_stale_deleted(
+    prefix: &str,
+    main_source: &str,
+    scanned_source: &str,
+) -> (BackendState, Url, std::path::PathBuf, Url) {
+    let dir = unique_temp_dir(prefix);
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", main_source);
+    let fresh = dir.join("fresh.sema");
+    insert_scanned_file(&mut state, &fresh, scanned_source);
+    let stale = dir.join("stale.sema");
+    insert_scanned_file(&mut state, &stale, scanned_source);
+    bump_mtime(&stale);
+    let deleted = dir.join("deleted.sema");
+    insert_scanned_file(&mut state, &deleted, scanned_source);
+    std::fs::remove_file(&deleted).unwrap();
+    let fresh_uri = Url::from_file_path(&fresh).unwrap();
+    (state, main_uri, dir, fresh_uri)
+}
+
+#[test]
+fn references_skip_stale_and_deleted_scan_cache_entries() {
+    let (state, main_uri, dir, fresh_uri) =
+        state_with_fresh_stale_deleted("refs-stale", "(define foo 1)\n(+ foo 1)\n", "(+ foo 2)\n");
+    let refs = state.handle_references(
+        &main_uri,
+        &Position {
+            line: 0,
+            character: 8,
+        },
+    );
+    let uris: Vec<&str> = refs.iter().map(|l| l.uri.as_str()).collect();
+    assert!(
+        uris.contains(&fresh_uri.as_str()),
+        "the fresh scan entry must contribute: {uris:?}"
+    );
+    assert_eq!(
+        refs.len(),
+        3,
+        "stale/deleted scan entries must not contribute: {refs:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn rename_skips_stale_and_deleted_scan_cache_entries() {
+    // Editing a file that changed since the scan would apply edits at stale
+    // offsets — skipping it is the safe behavior.
+    let (state, main_uri, dir, fresh_uri) = state_with_fresh_stale_deleted(
+        "rename-stale",
+        "(define foo 1)\n(+ foo 1)\n",
+        "(+ foo 2)\n",
+    );
+    let edit = state
+        .handle_rename(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 8,
+            },
+            "bar",
+        )
+        .expect("rename should produce edits");
+    let changes = edit.changes.expect("changes");
+    let mut uris: Vec<&str> = changes.keys().map(|u| u.as_str()).collect();
+    uris.sort_unstable();
+    let mut expected = vec![main_uri.as_str(), fresh_uri.as_str()];
+    expected.sort_unstable();
+    assert_eq!(
+        uris, expected,
+        "only the open document and the fresh scan entry may be edited"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn workspace_symbols_skip_stale_and_deleted_scan_cache_entries() {
+    let (state, _main_uri, dir, fresh_uri) =
+        state_with_fresh_stale_deleted("symbols-stale", "(define other 1)\n", "(define foo 1)\n");
+    let results = state.handle_workspace_symbols("foo");
+    let uris: Vec<&str> = results.iter().map(|s| s.location.uri.as_str()).collect();
+    assert_eq!(
+        uris,
+        vec![fresh_uri.as_str()],
+        "only the fresh scan entry may contribute symbols"
+    );
+    std::fs::remove_dir_all(&dir).ok();
 }

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -329,10 +329,13 @@ fn selection_range_unknown_uri_returns_none() {
 
 #[test]
 fn document_links_resolves_import_path() {
+    let dir = unique_temp_dir("doclinks");
+    std::fs::write(dir.join("foo.sema"), "(define x 1)\n").unwrap();
+    let main_uri = Url::from_file_path(dir.join("main.sema")).unwrap();
     //                       0         1         2
     //                       012345678901234567890
     let src = "(import \"./foo.sema\")";
-    let (state, uri) = parsed_state("file:///proj/main.sema", src);
+    let (state, uri) = parsed_state(main_uri.as_str(), src);
     let links = state.handle_document_links(&uri).expect("links");
     assert_eq!(links.len(), 1);
     let link = &links[0];
@@ -340,6 +343,19 @@ fn document_links_resolves_import_path() {
     assert_eq!(link.range.start.character, 9);
     assert_eq!(link.range.end.character, 19);
     assert!(link.target.as_ref().unwrap().path().ends_with("foo.sema"));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn document_links_skip_missing_files() {
+    // A link to a file that does not exist is a dead link — the import jump
+    // in goto-definition applies the same filter.
+    let src = "(import \"./missing.sema\")";
+    let (state, uri) = parsed_state("file:///proj/main.sema", src);
+    assert!(
+        state.handle_document_links(&uri).expect("links").is_empty(),
+        "an import of a nonexistent file must not produce a link"
+    );
 }
 
 #[test]

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1819,3 +1819,195 @@ fn completion_works_on_trailing_empty_line_after_newline() {
         "completion should offer items on the trailing empty line"
     );
 }
+
+// ── goto-definition: workspace-wide fallback (Phase 3d) ──────
+
+/// Parse `source` and insert it into `state` as an open document, mirroring
+/// the production build path (same steps as `parsed_state`).
+fn insert_parsed_doc(state: &mut BackendState, uri: &str, source: &str) {
+    let (ast, span_map, symbol_spans) = sema_reader::read_many_with_symbol_spans(source).unwrap();
+    let symbol_spans = crate::helpers::filter_quoted_symbol_spans(&ast, &span_map, symbol_spans);
+    let scope_tree = scope::ScopeTree::build(&ast, &span_map, &symbol_spans);
+    state.cached_parses.insert(
+        uri.to_string(),
+        CachedParse {
+            ast,
+            span_map,
+            symbol_spans,
+            scope_tree,
+            source: source.to_string(),
+        },
+    );
+    state.documents.insert(uri.to_string(), source.to_string());
+}
+
+/// Parse `source` and insert it into `state.import_cache` under `path`,
+/// as the post-`initialized` workspace scan does for unopened files.
+fn insert_scanned_file(state: &mut BackendState, path: &str, source: &str) {
+    let (ast, span_map, symbol_spans) = sema_reader::read_many_with_symbol_spans(source).unwrap();
+    let symbol_spans = crate::helpers::filter_quoted_symbol_spans(&ast, &span_map, symbol_spans);
+    let scope_tree = scope::ScopeTree::build(&ast, &span_map, &symbol_spans);
+    state.import_cache.insert(
+        std::path::PathBuf::from(path),
+        crate::state::ImportCache {
+            ast,
+            span_map,
+            symbol_spans,
+            scope_tree,
+            source: source.to_string(),
+            mtime: std::time::SystemTime::now(),
+        },
+    );
+}
+
+#[test]
+fn goto_definition_finds_symbol_in_other_open_document() {
+    // main.sema calls `greet` but neither defines nor imports it; the
+    // definition lives in a sibling document that happens to be open.
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_parsed_doc(
+        &mut state,
+        "file:///ws/library.sema",
+        "(define (greet name) name)\n",
+    );
+
+    // Cursor on `greet` in main.sema.
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("expected a cross-document definition");
+    match result {
+        GotoDefinitionResponse::Scalar(location) => {
+            assert_eq!(location.uri.as_str(), "file:///ws/library.sema");
+            assert_eq!(location.range.start.line, 0);
+        }
+        other => panic!("expected a scalar location, got {other:?}"),
+    }
+}
+
+#[test]
+fn goto_definition_finds_symbol_in_scanned_workspace_file() {
+    // The defining file was discovered by the workspace scan but never opened:
+    // it exists only in import_cache. No import statement links the two files.
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_scanned_file(
+        &mut state,
+        "/ws/library.sema",
+        "(define (greet name) name)\n",
+    );
+
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("expected a definition from the workspace scan cache");
+    match result {
+        GotoDefinitionResponse::Scalar(location) => {
+            assert_eq!(location.uri.as_str(), "file:///ws/library.sema");
+            assert_eq!(location.range.start.line, 0);
+        }
+        other => panic!("expected a scalar location, got {other:?}"),
+    }
+}
+
+#[test]
+fn goto_definition_returns_all_candidates_when_name_defined_in_multiple_files() {
+    // Two workspace files both define `greet`: cache iteration order is
+    // arbitrary, so the handler must return every candidate, not a coin flip.
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_scanned_file(&mut state, "/ws/a.sema", "(define (greet name) name)\n");
+    insert_scanned_file(&mut state, "/ws/b.sema", "(define (greet name) 42)\n");
+
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("expected definitions from both files");
+    match result {
+        GotoDefinitionResponse::Array(mut locations) => {
+            locations.sort_by(|a, b| a.uri.as_str().cmp(b.uri.as_str()));
+            let uris: Vec<&str> = locations.iter().map(|l| l.uri.as_str()).collect();
+            assert_eq!(uris, vec!["file:///ws/a.sema", "file:///ws/b.sema"]);
+        }
+        other => panic!("expected an array of locations, got {other:?}"),
+    }
+}
+
+#[test]
+fn goto_definition_skips_scan_cache_entry_for_open_document() {
+    // A file that is both open (cached_parses) and in the scan cache must not
+    // yield two locations for its single definition.
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", "(greet \"world\")\n");
+    insert_parsed_doc(
+        &mut state,
+        "file:///ws/library.sema",
+        "(define (greet name) name)\n",
+    );
+    insert_scanned_file(
+        &mut state,
+        "/ws/library.sema",
+        "(define (greet name) name)\n",
+    );
+
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: 1,
+            },
+        )
+        .expect("expected exactly one definition");
+    assert!(
+        matches!(result, GotoDefinitionResponse::Scalar(_)),
+        "open-document and scan-cache copies of the same file must dedup, got {result:?}"
+    );
+}
+
+#[test]
+fn goto_definition_still_prefers_local_scope_over_workspace() {
+    // A locally-bound `greet` must resolve to the local binding (Phase 3b),
+    // not fall through to a same-named definition elsewhere in the workspace.
+    let source = "(define (run) (let ((greet 1)) (greet)))\n";
+    let (mut state, main_uri) = parsed_state("file:///ws/main.sema", source);
+    insert_scanned_file(
+        &mut state,
+        "/ws/library.sema",
+        "(define (greet name) name)\n",
+    );
+
+    // Cursor on the `greet` call inside the `let` body (column of the second `greet`).
+    let call_col = source.rfind("greet").unwrap() as u32 + 1;
+    let result = state
+        .handle_goto_definition(
+            &main_uri,
+            &Position {
+                line: 0,
+                character: call_col,
+            },
+        )
+        .expect("expected the local binding");
+    match result {
+        GotoDefinitionResponse::Scalar(location) => {
+            assert_eq!(
+                location.uri.as_str(),
+                "file:///ws/main.sema",
+                "local let-binding must win over the workspace definition"
+            );
+        }
+        other => panic!("expected a scalar location, got {other:?}"),
+    }
+}

--- a/crates/sema-lsp/src/tests.rs
+++ b/crates/sema-lsp/src/tests.rs
@@ -1667,6 +1667,53 @@ fn semantic_token_length_is_utf16() {
     );
 }
 
+// Semantic-token START columns must be UTF-16 code units, same as lengths:
+// a raw char column for a token after an astral char on its line shifts the
+// token left, and the delta encoding propagates the shift to every later
+// token on that line.
+#[test]
+fn semantic_token_start_column_is_utf16_after_astral_char() {
+    // Line 2's `x` sits after a 🎉 string: char index 10, but UTF-16 column 11.
+    let src = "(define x 1)\n(list \"🎉\" x)";
+    let (state, uri) = parsed_state("file:///semtok2.sema", src);
+    let result = state.handle_semantic_tokens_full(&uri).unwrap();
+    let SemanticTokensResult::Tokens(tokens) = result else {
+        panic!("expected token data");
+    };
+    // Decode the delta encoding back to absolute (line, start) positions.
+    let mut absolute = Vec::new();
+    let (mut line, mut start) = (0u32, 0u32);
+    for token in &tokens.data {
+        line += token.delta_line;
+        start = if token.delta_line == 0 {
+            start + token.delta_start
+        } else {
+            token.delta_start
+        };
+        absolute.push((line, start));
+    }
+    assert!(
+        absolute.contains(&(1, 11)),
+        "token after 🎉 must start at UTF-16 column 11, got {absolute:?}"
+    );
+}
+
+// Folding-range columns must be UTF-16 code units, not char indices.
+#[test]
+fn folding_range_columns_are_utf16_after_astral_char() {
+    // The inner `(f a … c)` form starts after a 🎉 string on its line:
+    // char index 10, but UTF-16 column 11.
+    let src = "(list \"🎉\" (f a\n      b\n      c))";
+    let (state, uri) = parsed_state("file:///fold.sema", src);
+    let ranges = state.handle_folding_ranges(&uri);
+    assert!(
+        ranges
+            .iter()
+            .any(|r| r.start_line == 0 && r.start_character == Some(11)),
+        "inner form after 🎉 must fold from UTF-16 column 11, got {ranges:?}"
+    );
+}
+
 // LSP-1: completion scope queries must convert the incoming UTF-16
 // Position.character to a Sema (char) column. On a line containing an emoji
 // before the cursor, the raw `character + 1` would land in the wrong scope

--- a/crates/sema-lsp/tests/lsp_e2e_test.rs
+++ b/crates/sema-lsp/tests/lsp_e2e_test.rs
@@ -83,6 +83,61 @@ impl Drop for ServerGuard {
     }
 }
 
+/// Spawns `sema lsp` and completes the `initialize`/`initialized` handshake.
+fn start_initialized_server(
+    sema: &std::path::Path,
+) -> (
+    ServerGuard,
+    ChildStdin,
+    BufReader<std::process::ChildStdout>,
+) {
+    // Run from an empty temp dir so the `initialized` workspace scan finds nothing (fast + stable).
+    let mut child = Command::new(sema)
+        .arg("lsp")
+        .current_dir(std::env::temp_dir())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn `sema lsp`");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    let guard = ServerGuard(child);
+
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "processId": null, "rootUri": null, "capabilities": {} }
+        }),
+    );
+    wait_for_response(&mut reader, 1);
+    send(
+        &mut stdin,
+        &json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }),
+    );
+
+    (guard, stdin, reader)
+}
+
+/// Polls the child until it exits or `timeout` elapses.
+fn wait_for_exit(
+    child: &mut Child,
+    timeout: std::time::Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("wait on `sema lsp`") {
+            return Some(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
 #[test]
 fn lsp_formatting_and_selection_range_round_trip() {
     let Some(sema) = find_sema_binary() else {
@@ -103,7 +158,7 @@ fn lsp_formatting_and_selection_range_round_trip() {
 
     let mut stdin = child.stdin.take().unwrap();
     let mut reader = BufReader::new(child.stdout.take().unwrap());
-    let _guard = ServerGuard(child);
+    let mut guard = ServerGuard(child);
 
     // initialize
     send(
@@ -189,7 +244,8 @@ fn lsp_formatting_and_selection_range_round_trip() {
         "expected a parent selection range"
     );
 
-    // shutdown
+    // shutdown, await the response, then exit — the server must terminate
+    // promptly with code 0 (LSP lifecycle; regression for the exit hang).
     send(
         &mut stdin,
         &json!({ "jsonrpc": "2.0", "id": 4, "method": "shutdown", "params": null }),
@@ -199,4 +255,60 @@ fn lsp_formatting_and_selection_range_round_trip() {
         &mut stdin,
         &json!({ "jsonrpc": "2.0", "method": "exit", "params": null }),
     );
+    let status = wait_for_exit(&mut guard.0, std::time::Duration::from_secs(3))
+        .expect("server did not exit within 3s of shutdown + exit");
+    assert_eq!(status.code(), Some(0), "clean shutdown/exit must exit 0");
+}
+
+/// Regression: `shutdown` + `exit` sent back-to-back — without reading the
+/// shutdown response first — must terminate the process promptly with exit
+/// code 0. tower-lsp's own exit handling never ends the process (tower-lsp
+/// issue #399), so the stdio transport watches the lifecycle frames itself.
+#[test]
+fn lsp_exits_zero_on_immediate_shutdown_exit() {
+    let Some(sema) = find_sema_binary() else {
+        eprintln!("skipping lsp_e2e: `sema` binary not found next to test runner — build it first");
+        return;
+    };
+    let (mut guard, mut stdin, _reader) = start_initialized_server(&sema);
+
+    send(
+        &mut stdin,
+        &json!({ "jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": null }),
+    );
+    send(
+        &mut stdin,
+        &json!({ "jsonrpc": "2.0", "method": "exit", "params": null }),
+    );
+
+    let started = std::time::Instant::now();
+    let status = wait_for_exit(&mut guard.0, std::time::Duration::from_secs(3))
+        .expect("server did not exit within 3s of back-to-back shutdown + exit");
+    eprintln!("shutdown+exit terminated in {:?}", started.elapsed());
+    assert_eq!(status.code(), Some(0), "shutdown-then-exit must exit 0");
+}
+
+/// Regression: an `exit` notification without a prior `shutdown` request must
+/// terminate the process promptly with exit code 1 (per the LSP spec).
+#[test]
+fn lsp_exits_one_on_exit_without_shutdown() {
+    let Some(sema) = find_sema_binary() else {
+        eprintln!("skipping lsp_e2e: `sema` binary not found next to test runner — build it first");
+        return;
+    };
+    let (mut guard, mut stdin, _reader) = start_initialized_server(&sema);
+
+    send(
+        &mut stdin,
+        &json!({ "jsonrpc": "2.0", "method": "exit", "params": null }),
+    );
+
+    let started = std::time::Instant::now();
+    let status = wait_for_exit(&mut guard.0, std::time::Duration::from_secs(3))
+        .expect("server did not exit within 3s of exit-without-shutdown");
+    eprintln!(
+        "exit-without-shutdown terminated in {:?}",
+        started.elapsed()
+    );
+    assert_eq!(status.code(), Some(1), "exit without shutdown must exit 1");
 }


### PR DESCRIPTION
## Problem

`textDocument/definition` returns null for symbols defined in workspace files the current document does not explicitly import, even after the post-`initialized` workspace scan has parsed them. References and rename already treat top-level symbols as workspace-global and search the scan cache; goto-definition only followed the current file's `import`/`load` list. Found while wiring `sema lsp` into a new editor client and confirmed with a raw stdio session (null at every cursor position over a cross-file symbol).

An audit of the crate while fixing this surfaced seven adjacent correctness bugs, fixed here as well, and three sibling handlers with the same import-list-only shape, brought in line with the references model.

## Changes

- **Goto-definition falls back to a workspace-wide search** — open documents first, then fresh scan-cache entries with open-document dedup; returns all candidates (`Location[]`) when the same top-level name is defined in several files, since cache iteration order is arbitrary.
- **Semantic tokens and folding ranges emit UTF-16 columns** — start columns were raw char indices; any token after an astral char on the same line was shifted left, and delta encoding propagated the shift. Also hoists the per-token line lookup out of the loop (was O(n²)).
- **Inlay-hint arg scanning compares byte offsets against byte boundaries** — span char-columns were compared against `char_indices()` byte offsets, desyncing the string-state machine after non-ASCII text on the line.
- **Scan cache keyed and dedup'd by canonical path; stale entries invalidated** — the same file could live under two keys (unnormalized `..` import paths, symlinked roots like `/tmp` → `/private/tmp`), making rename emit a second, stale-positioned edit set for the same file. Entries for deleted or externally-modified files are now removed or skipped (`ImportCache::is_fresh`) instead of serving stale offsets to rename/references/symbols.
- **`prepare_rename` accepts the cursor at the symbol's end** — `<` → `<=`, matching `extract_symbol_at` and `rename` itself; clients gate the rename UI on prepare, so F2 at `foo|` previously reported the element unrenamable.
- **Workspace scanner follows symlinks** — `DirEntry::metadata()` does not traverse links, so symlinked directories and files were silently skipped and the symlink-cycle guard was dead code; a workspace reached through a symlink got no definition cache at all.
- **Document links only emitted for import paths that exist**, matching the goto-definition import jump.
- **Hover and signature help resolve workspace-wide** via a shared `find_workspace_definition` (precedence: explicit import > builtin docs > workspace match; workspace hover hits say *Defined in `file`* vs the import path's *Imported from*).
- **Call hierarchy includes scanned files** — `def_index` and incoming/outgoing calls walk the scan cache under the same dedup + freshness rules; open documents keep precedence.
- **Completion offers workspace-defined symbols** — scan-cache user definitions with params as detail, deduped behind special forms, builtins, and current-document definitions; `completionItem/resolve` enrichment picks up scanned definitions. Deliberately iterates the cache per request (the precedent references/rename already set) rather than adding a persistent index.

- **Exit notification terminates the server promptly** — three stacked issues: tower-lsp's `serve` future never resolves after `exit` (tower-lsp#399, the read loop stays parked on stdin); a back-to-back `shutdown`+`exit` aborts the still-queued shutdown handler via `cancel_all()`, so not even the 2 s watchdog armed (total hang); and `run_server` held the mpsc sender open while joining the backend thread. The inbound-frame normalizer now detects `exit`, gives the response 200 ms to flush, and exits 0/1 per spec (measured: ~0.22 s for all sequences, vs never / 2 s). The shutdown watchdog stays as a fallback.

## Testing

- 245 crate tests, up from 218 — every fix carries a regression test that fails on the previous behavior (astral-char fixtures for the column bugs, symlinked temp dirs for dedup and the scanner, real-file mtime manipulation for staleness).
- `cargo clippy --all-targets` warning-clean, `cargo fmt` applied.
- Live stdio verification against the built binary: definition, hover, and completion all resolve a symbol defined in a never-imported, never-opened sibling file discovered only by the workspace scan.
- No `crates/sema-lsp` conflicts with `codex/unified-async-runtime` (that branch touches the crate only via a `tests.rs` comment).

Known follow-up, not addressed here: the inlay-hint traversal never evaluates nested forms as call sites (pre-existing, independent of the byte/char fix).
