### PR TITLE
Make the Run code lens run code normally instead of always sandboxed (#126)

### DIFF
--- a/crates/sema-lsp/src/handlers/command.rs
+++ b/crates/sema-lsp/src/handlers/command.rs
@@ -105,10 +105,14 @@ impl BackendState {
             "eval".to_string(),
             "--stdin".to_string(),
             "--json".to_string(),
-            "--sandbox".to_string(),
-            "strict".to_string(),
-            "--no-llm".to_string(),
         ];
+
+        let is_strict = self.run_sandbox_mode == "strict";
+        if is_strict {
+            args.push("--sandbox".to_string());
+            args.push("strict".to_string());
+            args.push("--no-llm".to_string());
+        }
 
         // Add --path if the URI is a file
         if let Ok(path) = uri.to_file_path() {
@@ -160,7 +164,13 @@ impl BackendState {
                     let error = json.get("error").and_then(|v| {
                         v.get("message")
                             .and_then(|m| m.as_str())
-                            .map(|s| s.to_string())
+                            .map(|s| {
+                                let mut msg = s.to_string();
+                                if is_strict && (msg.contains("sandbox") || msg.contains("LLM") || msg.contains("effect")) {
+                                    msg.push_str(" (Run lens sandbox is 'strict'. Change 'sema.run.sandbox' setting to 'off' to allow this.)");
+                                }
+                                msg
+                            })
                     });
                     let eval_elapsed = json
                         .get("elapsedMs")

--- a/crates/sema-lsp/src/handlers/structure.rs
+++ b/crates/sema-lsp/src/handlers/structure.rs
@@ -41,8 +41,13 @@ impl BackendState {
         indexed_ranges
             .into_iter()
             .map(|(form_index, range)| {
+                let title = if self.run_sandbox_mode == "strict" {
+                    "▶ Run (strict)".to_string()
+                } else {
+                    "▶ Run".to_string()
+                };
                 let command = Command {
-                    title: "▶ Run".to_string(),
+                    title,
                     command: "sema.runTopLevel".to_string(),
                     arguments: Some(vec![serde_json::json!({
                         "uri": uri.as_str(),

--- a/crates/sema-lsp/src/server.rs
+++ b/crates/sema-lsp/src/server.rs
@@ -159,6 +159,8 @@ pub(crate) enum LspRequest {
     },
     /// Set the sema binary path (from initializationOptions).
     SetSemaBinary { path: String },
+    /// Set the run sandbox mode.
+    SetRunSandbox { mode: String },
     /// Scan workspace for .sema files (triggered on initialized).
     ScanWorkspace { root: PathBuf },
     /// Continue incremental workspace scanning (directory-by-directory with yielding).
@@ -195,6 +197,11 @@ impl LanguageServer for Backend {
             if let Some(path) = opts.get("semaPath").and_then(|v| v.as_str()) {
                 let _ = self.tx.send(LspRequest::SetSemaBinary {
                     path: path.to_string(),
+                });
+            }
+            if let Some(mode) = opts.get("sema.run.sandbox").and_then(|v| v.as_str()) {
+                let _ = self.tx.send(LspRequest::SetRunSandbox {
+                    mode: mode.to_string(),
                 });
             }
         }
@@ -1003,15 +1010,19 @@ pub async fn run_server() {
                         docs.insert(target_uri.to_string(), text.clone());
                     }
                     let sema_binary = state.sema_binary.clone();
+                    let run_sandbox_mode = state.run_sandbox_mode.clone();
                     let client = client.clone();
                     let handle = handle.clone();
                     std::thread::spawn(move || {
-                        let tmp = BackendState::new_without_builtins(docs, sema_binary);
+                        let tmp = BackendState::new_without_builtins(docs, sema_binary, run_sandbox_mode);
                         tmp.handle_execute_command(&command, &arguments, &client, &handle);
                     });
                 }
                 LspRequest::SetSemaBinary { path } => {
                     state.sema_binary = path;
+                }
+                LspRequest::SetRunSandbox { mode } => {
+                    state.run_sandbox_mode = mode;
                 }
                 LspRequest::ScanWorkspace { root } => {
                     // Start incremental workspace scanning. The scanner

--- a/crates/sema-lsp/src/state.rs
+++ b/crates/sema-lsp/src/state.rs
@@ -158,6 +158,8 @@ pub(crate) struct BackendState {
     pub(crate) cached_parses: HashMap<String, CachedParse>,
     /// Path to the sema binary (from initializationOptions or default).
     pub(crate) sema_binary: String,
+    /// Sandbox mode for code execution via Run code lens (e.g., "off", "strict").
+    pub(crate) run_sandbox_mode: String,
 }
 
 /// Resolve the default `sema` binary used by the eval subprocess.
@@ -334,6 +336,7 @@ impl BackendState {
             import_cache: HashMap::new(),
             cached_parses: HashMap::new(),
             sema_binary: default_sema_binary(),
+            run_sandbox_mode: "off".to_string(),
         }
     }
 
@@ -341,6 +344,7 @@ impl BackendState {
     pub(crate) fn new_without_builtins(
         documents: HashMap<String, String>,
         sema_binary: String,
+        run_sandbox_mode: String,
     ) -> Self {
         BackendState {
             builtin_names: HashSet::new(),
@@ -350,6 +354,7 @@ impl BackendState {
             import_cache: HashMap::new(),
             cached_parses: HashMap::new(),
             sema_binary,
+            run_sandbox_mode,
         }
     }
 


### PR DESCRIPTION
## What & why

The `▶ Run` code lens always ran forms with `--sandbox strict --no-llm` hardcoded, so it couldn't run LLM calls or shell/network/fs-write code — even though running the same file with `sema <file>`, or the editor's own eval command, runs it unsandboxed. "Run this form" should just run it. This makes Run behave like normal execution by default.

## How

- Removed the hardcoded `--sandbox strict --no-llm` from `sema.runTopLevel` in `crates/sema-lsp/src/handlers/command.rs`.
- Added an opt-in setting `sema.run.sandbox` (default off); set it to `strict` to keep the old sandboxed behavior for untrusted files.
- When a run fails because of a sandbox / no-LLM restriction, the `sema/evalResult` error now says so explicitly instead of looking like a generic failure.

## Verification

```bash
cargo build -p sema-lsp
cargo test  -p sema-lsp
git grep -n 'no-llm' crates/sema-lsp/src/handlers/command.rs
git grep -n 'run.sandbox\|run_sandbox' crates/sema-lsp/src
```

Manual check in VS Code: opened a `.sema` file with an LLM call at top level and clicked ▶ Run — it now runs (previously errored on the sandbox). Setting `sema.run.sandbox = strict` restores the sandboxed behavior.

Closes #126